### PR TITLE
Remove local seqNo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
 import com.typesafe.sbt.SbtMultiJvm
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
+import generate.protobuf._
 
 val akkaVersion = "2.3.5"
 
 val project = Project(
   id = "akka-datareplication",
   base = file("."),
-  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ bintrayPublishSettings ++ Seq(
+  settings = Project.defaultSettings ++ SbtMultiJvm.multiJvmSettings ++ bintrayPublishSettings ++ Protobuf.settings ++ Seq(
     organization := "com.github.patriknw",
     name := "akka-datareplication",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package generate.protobuf
+
+import sbt._
+import Process._
+import Keys._
+
+import java.io.File
+
+object Protobuf {
+  val paths = SettingKey[Seq[File]]("protobuf-paths", "The paths that contain *.proto files.")
+  val outputPaths = SettingKey[Seq[File]]("protobuf-output-paths", "The paths where to save the generated *.java files.")
+  val protoc = SettingKey[String]("protobuf-protoc", "The path and name of the protoc executable.")
+  val protocVersion = SettingKey[String]("protobuf-protoc-version", "The version of the protoc executable.")
+  val generate = TaskKey[Unit]("protobuf-generate", "Compile the protobuf sources and do all processing.")
+
+  lazy val settings: Seq[Setting[_]] = Seq(
+    paths <<= (sourceDirectory in Compile, sourceDirectory in Test) { (a, b) => Seq(a, b) map (_ / "protobuf") },
+    outputPaths <<= (sourceDirectory in Compile, sourceDirectory in Test) { (a, b) => Seq(a, b) map (_ / "java") },
+    protoc := "protoc",
+    protocVersion := "2.5.0",
+    generate <<= generateSourceTask
+  )
+
+  private def callProtoc[T](protoc: String, args: Seq[String], log: Logger, thunk: (ProcessBuilder, Logger) => T): T =
+    try {
+      val proc = Process(protoc, args)
+      thunk(proc, log)
+    } catch { case e: Exception =>
+      throw new RuntimeException("error while executing '%s' with args: %s" format(protoc, args.mkString(" ")), e)
+    }
+
+  private def checkProtocVersion(protoc: String, protocVersion: String, log: Logger): Unit = {
+    val res = callProtoc(protoc, Seq("--version"), log, { (p, l) => p !! l })
+    val version = res.split(" ").last.trim
+    if (version != protocVersion) {
+      sys.error("Wrong protoc version! Expected %s but got %s" format (protocVersion, version))
+    }
+  }
+
+  private def generate(protoc: String, srcDir: File, targetDir: File, log: Logger): Unit = {
+    val protoFiles = (srcDir ** "*.proto").get
+    if (srcDir.exists)
+      if (protoFiles.isEmpty)
+        log.info("Skipping empty source directory %s" format srcDir)
+      else {
+        targetDir.mkdirs()
+
+        log.info("Generating %d protobuf files from %s to %s".format(protoFiles.size, srcDir, targetDir))
+        protoFiles.foreach { proto => log.info("Compiling %s" format proto) }
+
+        val exitCode = callProtoc(protoc, Seq("-I" + srcDir.absolutePath, "--java_out=%s" format targetDir.absolutePath) ++
+          protoFiles.map(_.absolutePath), log, { (p, l) => p ! l })
+        if (exitCode != 0)
+          sys.error("protoc returned exit code: %d" format exitCode)
+      }
+  }
+
+  private def generateSourceTask: Project.Initialize[Task[Unit]] = (streams, paths, outputPaths, protoc, protocVersion) map {
+    (out, sourceDirs, targetDirs, protoc, protocVersion) =>
+      if (sourceDirs.size != targetDirs.size)
+        sys.error("Unbalanced number of paths and destination paths!\nPaths: %s\nDestination Paths: %s" format
+          (sourceDirs, targetDirs))
+
+      if (sourceDirs exists { _.exists }) {
+        checkProtocVersion(protoc, protocVersion, out.log)
+
+        (sourceDirs zip targetDirs) map {
+          case (sourceDir, targetDir) =>
+            generate(protoc, sourceDir, targetDir, out.log)
+        }
+      }
+  }
+}

--- a/src/main/java/akka/contrib/datareplication/protobuf/msg/ReplicatorMessages.java
+++ b/src/main/java/akka/contrib/datareplication/protobuf/msg/ReplicatorMessages.java
@@ -901,16 +901,6 @@ public final class ReplicatorMessages {
      */
     akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessageOrBuilder getDataOrBuilder();
 
-    // required int64 seqNo = 3;
-    /**
-     * <code>required int64 seqNo = 3;</code>
-     */
-    boolean hasSeqNo();
-    /**
-     * <code>required int64 seqNo = 3;</code>
-     */
-    long getSeqNo();
-
     // optional .akka.contrib.datareplication.OtherMessage request = 4;
     /**
      * <code>optional .akka.contrib.datareplication.OtherMessage request = 4;</code>
@@ -994,14 +984,9 @@ public final class ReplicatorMessages {
               bitField0_ |= 0x00000002;
               break;
             }
-            case 24: {
-              bitField0_ |= 0x00000004;
-              seqNo_ = input.readInt64();
-              break;
-            }
             case 34: {
               akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.Builder subBuilder = null;
-              if (((bitField0_ & 0x00000008) == 0x00000008)) {
+              if (((bitField0_ & 0x00000004) == 0x00000004)) {
                 subBuilder = request_.toBuilder();
               }
               request_ = input.readMessage(akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.PARSER, extensionRegistry);
@@ -1009,7 +994,7 @@ public final class ReplicatorMessages {
                 subBuilder.mergeFrom(request_);
                 request_ = subBuilder.buildPartial();
               }
-              bitField0_ |= 0x00000008;
+              bitField0_ |= 0x00000004;
               break;
             }
           }
@@ -1117,22 +1102,6 @@ public final class ReplicatorMessages {
       return data_;
     }
 
-    // required int64 seqNo = 3;
-    public static final int SEQNO_FIELD_NUMBER = 3;
-    private long seqNo_;
-    /**
-     * <code>required int64 seqNo = 3;</code>
-     */
-    public boolean hasSeqNo() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    /**
-     * <code>required int64 seqNo = 3;</code>
-     */
-    public long getSeqNo() {
-      return seqNo_;
-    }
-
     // optional .akka.contrib.datareplication.OtherMessage request = 4;
     public static final int REQUEST_FIELD_NUMBER = 4;
     private akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage request_;
@@ -1140,7 +1109,7 @@ public final class ReplicatorMessages {
      * <code>optional .akka.contrib.datareplication.OtherMessage request = 4;</code>
      */
     public boolean hasRequest() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <code>optional .akka.contrib.datareplication.OtherMessage request = 4;</code>
@@ -1158,7 +1127,6 @@ public final class ReplicatorMessages {
     private void initFields() {
       key_ = "";
       data_ = akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.getDefaultInstance();
-      seqNo_ = 0L;
       request_ = akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
@@ -1171,10 +1139,6 @@ public final class ReplicatorMessages {
         return false;
       }
       if (!hasData()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!hasSeqNo()) {
         memoizedIsInitialized = 0;
         return false;
       }
@@ -1202,9 +1166,6 @@ public final class ReplicatorMessages {
         output.writeMessage(2, data_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeInt64(3, seqNo_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeMessage(4, request_);
       }
       getUnknownFields().writeTo(output);
@@ -1225,10 +1186,6 @@ public final class ReplicatorMessages {
           .computeMessageSize(2, data_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(3, seqNo_);
-      }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, request_);
       }
@@ -1358,14 +1315,12 @@ public final class ReplicatorMessages {
           dataBuilder_.clear();
         }
         bitField0_ = (bitField0_ & ~0x00000002);
-        seqNo_ = 0L;
-        bitField0_ = (bitField0_ & ~0x00000004);
         if (requestBuilder_ == null) {
           request_ = akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.getDefaultInstance();
         } else {
           requestBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -1409,10 +1364,6 @@ public final class ReplicatorMessages {
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
         }
-        result.seqNo_ = seqNo_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
-        }
         if (requestBuilder_ == null) {
           result.request_ = request_;
         } else {
@@ -1442,9 +1393,6 @@ public final class ReplicatorMessages {
         if (other.hasData()) {
           mergeData(other.getData());
         }
-        if (other.hasSeqNo()) {
-          setSeqNo(other.getSeqNo());
-        }
         if (other.hasRequest()) {
           mergeRequest(other.getRequest());
         }
@@ -1458,10 +1406,6 @@ public final class ReplicatorMessages {
           return false;
         }
         if (!hasData()) {
-          
-          return false;
-        }
-        if (!hasSeqNo()) {
           
           return false;
         }
@@ -1688,39 +1632,6 @@ public final class ReplicatorMessages {
         return dataBuilder_;
       }
 
-      // required int64 seqNo = 3;
-      private long seqNo_ ;
-      /**
-       * <code>required int64 seqNo = 3;</code>
-       */
-      public boolean hasSeqNo() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
-      }
-      /**
-       * <code>required int64 seqNo = 3;</code>
-       */
-      public long getSeqNo() {
-        return seqNo_;
-      }
-      /**
-       * <code>required int64 seqNo = 3;</code>
-       */
-      public Builder setSeqNo(long value) {
-        bitField0_ |= 0x00000004;
-        seqNo_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <code>required int64 seqNo = 3;</code>
-       */
-      public Builder clearSeqNo() {
-        bitField0_ = (bitField0_ & ~0x00000004);
-        seqNo_ = 0L;
-        onChanged();
-        return this;
-      }
-
       // optional .akka.contrib.datareplication.OtherMessage request = 4;
       private akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage request_ = akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.getDefaultInstance();
       private com.google.protobuf.SingleFieldBuilder<
@@ -1729,7 +1640,7 @@ public final class ReplicatorMessages {
        * <code>optional .akka.contrib.datareplication.OtherMessage request = 4;</code>
        */
       public boolean hasRequest() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <code>optional .akka.contrib.datareplication.OtherMessage request = 4;</code>
@@ -1754,7 +1665,7 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.setMessage(value);
         }
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000004;
         return this;
       }
       /**
@@ -1768,7 +1679,7 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.setMessage(builderForValue.build());
         }
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000004;
         return this;
       }
       /**
@@ -1776,7 +1687,7 @@ public final class ReplicatorMessages {
        */
       public Builder mergeRequest(akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage value) {
         if (requestBuilder_ == null) {
-          if (((bitField0_ & 0x00000008) == 0x00000008) &&
+          if (((bitField0_ & 0x00000004) == 0x00000004) &&
               request_ != akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.getDefaultInstance()) {
             request_ =
               akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.newBuilder(request_).mergeFrom(value).buildPartial();
@@ -1787,7 +1698,7 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000004;
         return this;
       }
       /**
@@ -1800,14 +1711,14 @@ public final class ReplicatorMessages {
         } else {
           requestBuilder_.clear();
         }
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
       /**
        * <code>optional .akka.contrib.datareplication.OtherMessage request = 4;</code>
        */
       public akka.contrib.datareplication.protobuf.msg.ReplicatorMessages.OtherMessage.Builder getRequestBuilder() {
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000004;
         onChanged();
         return getRequestFieldBuilder().getBuilder();
       }
@@ -14598,48 +14509,48 @@ public final class ReplicatorMessages {
       ".datareplication\"u\n\003Get\022\013\n\003key\030\001 \002(\t\022\023\n\013" +
       "consistency\030\002 \002(\005\022\017\n\007timeout\030\003 \002(\005\022;\n\007re" +
       "quest\030\004 \001(\0132*.akka.contrib.datareplicati" +
-      "on.OtherMessage\"\237\001\n\nGetSuccess\022\013\n\003key\030\001 " +
+      "on.OtherMessage\"\220\001\n\nGetSuccess\022\013\n\003key\030\001 " +
       "\002(\t\0228\n\004data\030\002 \002(\0132*.akka.contrib.datarep" +
-      "lication.OtherMessage\022\r\n\005seqNo\030\003 \002(\003\022;\n\007" +
-      "request\030\004 \001(\0132*.akka.contrib.datareplica" +
-      "tion.OtherMessage\"T\n\010NotFound\022\013\n\003key\030\001 \002" +
-      "(\t\022;\n\007request\030\002 \001(\0132*.akka.contrib.datar",
-      "eplication.OtherMessage\"V\n\nGetFailure\022\013\n" +
-      "\003key\030\001 \002(\t\022;\n\007request\030\002 \001(\0132*.akka.contr" +
-      "ib.datareplication.OtherMessage\"%\n\tSubsc" +
-      "ribe\022\013\n\003key\030\001 \002(\t\022\013\n\003ref\030\002 \002(\t\"\'\n\013Unsubs" +
-      "cribe\022\013\n\003key\030\001 \002(\t\022\013\n\003ref\030\002 \002(\t\"P\n\007Chang" +
-      "ed\022\013\n\003key\030\001 \002(\t\0228\n\004data\030\002 \002(\0132*.akka.con" +
-      "trib.datareplication.OtherMessage\"R\n\005Wri" +
-      "te\022\013\n\003key\030\001 \002(\t\022<\n\010envelope\030\002 \002(\0132*.akka" +
-      ".contrib.datareplication.DataEnvelope\"\007\n" +
-      "\005Empty\"\023\n\004Read\022\013\n\003key\030\001 \002(\t\"J\n\nReadResul",
-      "t\022<\n\010envelope\030\001 \001(\0132*.akka.contrib.datar" +
-      "eplication.DataEnvelope\"\363\002\n\014DataEnvelope" +
-      "\0228\n\004data\030\001 \002(\0132*.akka.contrib.datareplic" +
-      "ation.OtherMessage\022H\n\007pruning\030\002 \003(\01327.ak" +
-      "ka.contrib.datareplication.DataEnvelope." +
-      "PruningEntry\032\336\001\n\014PruningEntry\022C\n\016removed" +
-      "Address\030\001 \002(\0132+.akka.contrib.datareplica" +
-      "tion.UniqueAddress\022A\n\014ownerAddress\030\002 \002(\013" +
-      "2+.akka.contrib.datareplication.UniqueAd" +
-      "dress\022\021\n\tperformed\030\003 \002(\010\0223\n\004seen\030\004 \003(\0132%",
-      ".akka.contrib.datareplication.Address\"k\n" +
-      "\006Status\022;\n\007entries\030\001 \003(\0132*.akka.contrib." +
-      "datareplication.Status.Entry\032$\n\005Entry\022\013\n" +
-      "\003key\030\001 \002(\t\022\016\n\006digest\030\002 \002(\014\"\231\001\n\006Gossip\022;\n" +
-      "\007entries\030\001 \003(\0132*.akka.contrib.datareplic" +
-      "ation.Gossip.Entry\032R\n\005Entry\022\013\n\003key\030\001 \002(\t" +
+      "lication.OtherMessage\022;\n\007request\030\004 \001(\0132*" +
+      ".akka.contrib.datareplication.OtherMessa" +
+      "ge\"T\n\010NotFound\022\013\n\003key\030\001 \002(\t\022;\n\007request\030\002" +
+      " \001(\0132*.akka.contrib.datareplication.Othe",
+      "rMessage\"V\n\nGetFailure\022\013\n\003key\030\001 \002(\t\022;\n\007r" +
+      "equest\030\002 \001(\0132*.akka.contrib.datareplicat" +
+      "ion.OtherMessage\"%\n\tSubscribe\022\013\n\003key\030\001 \002" +
+      "(\t\022\013\n\003ref\030\002 \002(\t\"\'\n\013Unsubscribe\022\013\n\003key\030\001 " +
+      "\002(\t\022\013\n\003ref\030\002 \002(\t\"P\n\007Changed\022\013\n\003key\030\001 \002(\t" +
+      "\0228\n\004data\030\002 \002(\0132*.akka.contrib.datareplic" +
+      "ation.OtherMessage\"R\n\005Write\022\013\n\003key\030\001 \002(\t" +
       "\022<\n\010envelope\030\002 \002(\0132*.akka.contrib.datare" +
-      "plication.DataEnvelope\"T\n\rUniqueAddress\022" +
-      "6\n\007address\030\001 \002(\0132%.akka.contrib.datarepl" +
-      "ication.Address\022\013\n\003uid\030\002 \002(\r\"K\n\007Address\022",
-      "\016\n\006system\030\001 \002(\t\022\020\n\010hostname\030\002 \002(\t\022\014\n\004por" +
-      "t\030\003 \002(\r\022\020\n\010protocol\030\004 \001(\t\"V\n\014OtherMessag" +
-      "e\022\027\n\017enclosedMessage\030\001 \002(\014\022\024\n\014serializer" +
-      "Id\030\002 \002(\005\022\027\n\017messageManifest\030\004 \001(\014\"\036\n\nStr" +
-      "ingGSet\022\020\n\010elements\030\001 \003(\tB-\n)akka.contri" +
-      "b.datareplication.protobuf.msgH\001"
+      "plication.DataEnvelope\"\007\n\005Empty\"\023\n\004Read\022" +
+      "\013\n\003key\030\001 \002(\t\"J\n\nReadResult\022<\n\010envelope\030\001",
+      " \001(\0132*.akka.contrib.datareplication.Data" +
+      "Envelope\"\363\002\n\014DataEnvelope\0228\n\004data\030\001 \002(\0132" +
+      "*.akka.contrib.datareplication.OtherMess" +
+      "age\022H\n\007pruning\030\002 \003(\01327.akka.contrib.data" +
+      "replication.DataEnvelope.PruningEntry\032\336\001" +
+      "\n\014PruningEntry\022C\n\016removedAddress\030\001 \002(\0132+" +
+      ".akka.contrib.datareplication.UniqueAddr" +
+      "ess\022A\n\014ownerAddress\030\002 \002(\0132+.akka.contrib" +
+      ".datareplication.UniqueAddress\022\021\n\tperfor" +
+      "med\030\003 \002(\010\0223\n\004seen\030\004 \003(\0132%.akka.contrib.d",
+      "atareplication.Address\"k\n\006Status\022;\n\007entr" +
+      "ies\030\001 \003(\0132*.akka.contrib.datareplication" +
+      ".Status.Entry\032$\n\005Entry\022\013\n\003key\030\001 \002(\t\022\016\n\006d" +
+      "igest\030\002 \002(\014\"\231\001\n\006Gossip\022;\n\007entries\030\001 \003(\0132" +
+      "*.akka.contrib.datareplication.Gossip.En" +
+      "try\032R\n\005Entry\022\013\n\003key\030\001 \002(\t\022<\n\010envelope\030\002 " +
+      "\002(\0132*.akka.contrib.datareplication.DataE" +
+      "nvelope\"T\n\rUniqueAddress\0226\n\007address\030\001 \002(" +
+      "\0132%.akka.contrib.datareplication.Address" +
+      "\022\013\n\003uid\030\002 \002(\r\"K\n\007Address\022\016\n\006system\030\001 \002(\t",
+      "\022\020\n\010hostname\030\002 \002(\t\022\014\n\004port\030\003 \002(\r\022\020\n\010prot" +
+      "ocol\030\004 \001(\t\"V\n\014OtherMessage\022\027\n\017enclosedMe" +
+      "ssage\030\001 \002(\014\022\024\n\014serializerId\030\002 \002(\005\022\027\n\017mes" +
+      "sageManifest\030\004 \001(\014\"\036\n\nStringGSet\022\020\n\010elem" +
+      "ents\030\001 \003(\tB-\n)akka.contrib.datareplicati" +
+      "on.protobuf.msgH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -14657,7 +14568,7 @@ public final class ReplicatorMessages {
           internal_static_akka_contrib_datareplication_GetSuccess_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_akka_contrib_datareplication_GetSuccess_descriptor,
-              new java.lang.String[] { "Key", "Data", "SeqNo", "Request", });
+              new java.lang.String[] { "Key", "Data", "Request", });
           internal_static_akka_contrib_datareplication_NotFound_descriptor =
             getDescriptor().getMessageTypes().get(2);
           internal_static_akka_contrib_datareplication_NotFound_fieldAccessorTable = new

--- a/src/main/protobuf/ReplicatorMessages.proto
+++ b/src/main/protobuf/ReplicatorMessages.proto
@@ -16,7 +16,6 @@ message Get {
 message GetSuccess {
   required string key = 1;
   required OtherMessage data = 2;
-  required int64 seqNo = 3;
   optional OtherMessage request = 4;
 }
 

--- a/src/main/scala/akka/contrib/datareplication/protobuf/ReplicatorMessageSerializer.scala
+++ b/src/main/scala/akka/contrib/datareplication/protobuf/ReplicatorMessageSerializer.scala
@@ -138,8 +138,7 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem) extends Seria
   private def getSuccessToProto(getSuccess: GetSuccess): dm.GetSuccess = {
     val b = dm.GetSuccess.newBuilder().
       setKey(getSuccess.key).
-      setData(otherMessageToProto(getSuccess.data)).
-      setSeqNo(getSuccess.seqNo)
+      setData(otherMessageToProto(getSuccess.data))
 
     getSuccess.request.foreach(o ⇒ b.setRequest(otherMessageToProto(o)))
     b.build()
@@ -149,7 +148,7 @@ class ReplicatorMessageSerializer(val system: ExtendedActorSystem) extends Seria
     val getSuccess = dm.GetSuccess.parseFrom(bytes)
     val request = if (getSuccess.hasRequest()) Some(otherMessageFromProto(getSuccess.getRequest)) else None
     val data = otherMessageFromProto(getSuccess.getData).asInstanceOf[ReplicatedData]
-    GetSuccess(getSuccess.getKey, data, getSuccess.getSeqNo, request)
+    GetSuccess(getSuccess.getKey, data, request)
   }
 
   private def notFoundToProto(notFound: NotFound): dm.NotFound = {

--- a/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorChaosSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorChaosSpec.scala
@@ -59,10 +59,10 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
       awaitAssert {
         replicator ! Get(key)
         val value = expectMsgPF() {
-          case GetSuccess(`key`, c: GCounter, _, _)  ⇒ c.value
-          case GetSuccess(`key`, c: PNCounter, _, _) ⇒ c.value
-          case GetSuccess(`key`, c: GSet, _, _)      ⇒ c.value
-          case GetSuccess(`key`, c: ORSet, _, _)     ⇒ c.value
+          case GetSuccess(`key`, c: GCounter, _)  ⇒ c.value
+          case GetSuccess(`key`, c: PNCounter, _) ⇒ c.value
+          case GetSuccess(`key`, c: GSet, _)      ⇒ c.value
+          case GetSuccess(`key`, c: ORSet, _)     ⇒ c.value
         }
         value should be(expected)
       }
@@ -98,9 +98,9 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
         (0 until 5) foreach { i ⇒
           c += 1
           pn -= 1
-          replicator ! Update("A", c, i)
-          replicator ! Update("B", pn, i)
-          replicator ! Update("C", c, i, WriteAll, timeout)
+          replicator ! Update("A", c)
+          replicator ! Update("B", pn)
+          replicator ! Update("C", c, WriteAll, timeout)
         }
         receiveN(15).map(_.getClass).toSet should be(Set(classOf[UpdateSuccess]))
       }
@@ -108,35 +108,35 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
       runOn(second) {
         val c = GCounter() + 20
         val pn = PNCounter() + 20
-        replicator ! Update("A", c, 0)
-        replicator ! Update("B", pn, 0, WriteTwo, timeout)
-        replicator ! Update("C", c, 0, WriteAll, timeout)
-        receiveN(3).toSet should be(Set(UpdateSuccess("A", 0, None),
-          UpdateSuccess("B", 0, None), UpdateSuccess("C", 0, None)))
+        replicator ! Update("A", c)
+        replicator ! Update("B", pn, WriteTwo, timeout)
+        replicator ! Update("C", c, WriteAll, timeout)
+        receiveN(3).toSet should be(Set(UpdateSuccess("A", None),
+          UpdateSuccess("B", None), UpdateSuccess("C", None)))
 
-        replicator ! Update("E", GSet() + "e1" + "e2", 0)
-        expectMsg(UpdateSuccess("E", 0, None))
+        replicator ! Update("E", GSet() + "e1" + "e2")
+        expectMsg(UpdateSuccess("E", None))
 
-        replicator ! Update("F", ORSet() + "e1" + "e2", 0)
-        expectMsg(UpdateSuccess("F", 0, None))
+        replicator ! Update("F", ORSet() + "e1" + "e2")
+        expectMsg(UpdateSuccess("F", None))
       }
 
       runOn(fourth) {
         val c = GCounter() + 40
-        replicator ! Update("D", c, 0)
-        expectMsg(UpdateSuccess("D", 0, None))
+        replicator ! Update("D", c)
+        expectMsg(UpdateSuccess("D", None))
 
-        replicator ! Update("E", GSet() + "e2" + "e3", 0)
-        expectMsg(UpdateSuccess("E", 0, None))
+        replicator ! Update("E", GSet() + "e2" + "e3")
+        expectMsg(UpdateSuccess("E", None))
 
-        replicator ! Update("F", ORSet() + "e2" + "e3", 0)
-        expectMsg(UpdateSuccess("F", 0, None))
+        replicator ! Update("F", ORSet() + "e2" + "e3")
+        expectMsg(UpdateSuccess("F", None))
       }
 
       runOn(fifth) {
         val c = GCounter() + 50
-        replicator ! Update("X", c, 0, WriteTwo, timeout)
-        expectMsg(UpdateSuccess("X", 0, None))
+        replicator ! Update("X", c, WriteTwo, timeout)
+        expectMsg(UpdateSuccess("X", None))
         replicator ! Delete("X")
         expectMsg(DeleteSuccess("X"))
       }
@@ -164,32 +164,32 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
 
       runOn(first) {
         replicator ! Get("A")
-        val GetSuccess("A", c: GCounter, seqNo, _) = expectMsgType[GetSuccess]
-        replicator ! Update("A", c + 1, seqNo, WriteTwo, timeout)
-        expectMsg(UpdateSuccess("A", seqNo, None))
+        val GetSuccess("A", c: GCounter, _) = expectMsgType[GetSuccess]
+        replicator ! Update("A", c + 1, WriteTwo, timeout)
+        expectMsg(UpdateSuccess("A", None))
       }
 
       runOn(third) {
         replicator ! Get("A")
-        val GetSuccess("A", c: GCounter, seqNo, _) = expectMsgType[GetSuccess]
-        replicator ! Update("A", c + 2, seqNo, WriteTwo, timeout)
-        expectMsg(UpdateSuccess("A", seqNo, None))
+        val GetSuccess("A", c: GCounter, _) = expectMsgType[GetSuccess]
+        replicator ! Update("A", c + 2, WriteTwo, timeout)
+        expectMsg(UpdateSuccess("A", None))
 
         replicator ! Get("E")
-        val GetSuccess("E", sE: GSet, seqNo2, _) = expectMsgType[GetSuccess]
-        replicator ! Update("E", sE + "e4", seqNo2, WriteTwo, timeout)
-        expectMsg(UpdateSuccess("E", seqNo, None))
+        val GetSuccess("E", sE: GSet, _) = expectMsgType[GetSuccess]
+        replicator ! Update("E", sE + "e4", WriteTwo, timeout)
+        expectMsg(UpdateSuccess("E", None))
 
         replicator ! Get("F")
-        val GetSuccess("F", sF: ORSet, seqNo3, _) = expectMsgType[GetSuccess]
-        replicator ! Update("F", sF - "e2", seqNo3, WriteTwo, timeout)
-        expectMsg(UpdateSuccess("F", seqNo, None))
+        val GetSuccess("F", sF: ORSet, _) = expectMsgType[GetSuccess]
+        replicator ! Update("F", sF - "e2", WriteTwo, timeout)
+        expectMsg(UpdateSuccess("F", None))
       }
       runOn(fourth) {
         replicator ! Get("D")
-        val GetSuccess("D", c: GCounter, seqNo, _) = expectMsgType[GetSuccess]
-        replicator ! Update("D", c + 1, seqNo, WriteTwo, timeout)
-        expectMsg(UpdateSuccess("D", seqNo, None))
+        val GetSuccess("D", c: GCounter, _) = expectMsgType[GetSuccess]
+        replicator ! Update("D", c + 1, WriteTwo, timeout)
+        expectMsg(UpdateSuccess("D", None))
       }
       enterBarrier("update-during-split")
 

--- a/src/test/scala/akka/contrib/datareplication/protobuf/ReplicatorMessageSerializerSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/protobuf/ReplicatorMessageSerializerSpec.scala
@@ -49,8 +49,8 @@ class ReplicatorMessageSerializerSpec extends TestKit(ActorSystem("ReplicatorMes
 
       checkSerialization(Get("A"))
       checkSerialization(Get("A", ReadQuorum, 2.seconds, Some("x")))
-      checkSerialization(GetSuccess("A", data1, 17, None))
-      checkSerialization(GetSuccess("A", data1, 17, Some("x")))
+      checkSerialization(GetSuccess("A", data1, None))
+      checkSerialization(GetSuccess("A", data1, Some("x")))
       checkSerialization(NotFound("A", Some("x")))
       checkSerialization(GetFailure("A", Some("x")))
       checkSerialization(Subscribe("A", ref1))

--- a/src/test/scala/akka/contrib/datareplication/sample/DataBot.scala
+++ b/src/test/scala/akka/contrib/datareplication/sample/DataBot.scala
@@ -68,7 +68,6 @@ class DataBot extends Actor with ActorLogging {
 
   replicator ! Subscribe("key", self)
 
-  var seqNo = 0L
   var current = ORSet()
 
   def receive = {
@@ -78,14 +77,13 @@ class DataBot extends Actor with ActorLogging {
         // add
         val newData = current + s
         log.info("Adding: {}", s)
-        replicator ! Update("key", newData, seqNo)
+        replicator ! Update("key", newData)
       } else {
         // remove
         val newData = current - s
         log.info("Removing: {}", s)
-        replicator ! Update("key", newData, seqNo)
+        replicator ! Update("key", newData)
       }
-      seqNo += 1
 
     case Changed("key", data: ORSet) =>
       current = data


### PR DESCRIPTION
- It does not provide the safetey that was intended
- The seqNo must be used as in the ReplicatedShoppingCartSpec example,
  i.e. get-modify-update cycle with stashing in-between, and that is too
  complicated and too easy to get wrong
- Disabled RemovedNodePruning for now

Refs #16
