### PR TITLE
Change style of higher-order functions

### DIFF
--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -50,7 +50,7 @@ object Protobuf {
         targetDir.mkdirs()
 
         log.info("Generating %d protobuf files from %s to %s".format(protoFiles.size, srcDir, targetDir))
-        protoFiles.foreach { proto => log.info("Compiling %s" format proto) }
+        protoFiles foreach { proto => log.info("Compiling %s" format proto) }
 
         val exitCode = callProtoc(protoc, Seq("-I" + srcDir.absolutePath, "--java_out=%s" format targetDir.absolutePath) ++
           protoFiles.map(_.absolutePath), log, { (p, l) => p ! l })

--- a/src/main/scala/akka/contrib/datareplication/LWWMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/LWWMap.scala
@@ -33,7 +33,7 @@ case class LWWMap(
 
   type T = LWWMap
 
-  def entries: Map[String, Any] = underlying.entries.map { case (k, r: LWWRegister) ⇒ k -> r.value }
+  def entries: Map[String, Any] = underlying.entries map { case (k, r: LWWRegister) ⇒ k -> r.value }
 
   def get(key: String): Option[Any] = underlying.get(key) match {
     case Some(r: LWWRegister) ⇒ Some(r.value)

--- a/src/main/scala/akka/contrib/datareplication/ORMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/ORMap.scala
@@ -111,10 +111,10 @@ case class ORMap(
   }
 
   override def needPruningFrom(removedNode: UniqueAddress): Boolean = {
-    keys.needPruningFrom(removedNode) || values.exists {
+    keys.needPruningFrom(removedNode) || (values exists {
       case (_, data: RemovedNodePruning) ⇒ data.needPruningFrom(removedNode)
       case _                             ⇒ false
-    }
+    })
   }
 
   override def prune(removedNode: UniqueAddress, collapseInto: UniqueAddress): ORMap = {

--- a/src/main/scala/akka/contrib/datareplication/ORSet.scala
+++ b/src/main/scala/akka/contrib/datareplication/ORSet.scala
@@ -65,7 +65,7 @@ object ORSet {
       case (acc, k) ⇒
         val lhsDots = lhs.elements(k).versions
         val rhsDots = rhs.elements(k).versions
-        val commonDots = lhsDots.filter {
+        val commonDots = lhsDots filter {
           case (thisDotNode, v) ⇒ rhsDots.get(thisDotNode).exists(_ == v)
         }
         val commonDotsKeys = commonDots.keys

--- a/src/main/scala/akka/contrib/datareplication/PNCounterMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/PNCounterMap.scala
@@ -29,7 +29,7 @@ case class PNCounterMap(
 
   type T = PNCounterMap
 
-  def entries: Map[String, Long] = underlying.entries.map { case (k, c: PNCounter) ⇒ k -> c.value }
+  def entries: Map[String, Long] = underlying.entries map { case (k, c: PNCounter) ⇒ k -> c.value }
 
   def get(key: String): Option[Long] = underlying.get(key) match {
     case Some(c: PNCounter) ⇒ Some(c.value)

--- a/src/main/scala/akka/contrib/datareplication/VectorClock.scala
+++ b/src/main/scala/akka/contrib/datareplication/VectorClock.scala
@@ -222,5 +222,5 @@ final case class VectorClock(
 
   override def pruningCleanup(removedNode: UniqueAddress): VectorClock = copy(versions = versions - removedNode)
 
-  override def toString = versions.map { case ((n, t)) ⇒ n + " -> " + t }.mkString("VectorClock(", ", ", ")")
+  override def toString = (versions map { case ((n, t)) ⇒ n + " -> " + t }).mkString("VectorClock(", ", ", ")")
 }

--- a/src/main/scala/akka/contrib/datareplication/protobuf/ReplicatedDataSerializer.scala
+++ b/src/main/scala/akka/contrib/datareplication/protobuf/ReplicatedDataSerializer.scala
@@ -83,7 +83,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
     val intElements = new ArrayList[Integer]
     val longElements = new ArrayList[jl.Long]
     val otherElements = new ArrayList[dm.OtherMessage]
-    gset.elements.foreach {
+    gset.elements foreach {
       case s: String ⇒ stringElements.add(s)
       case i: Int    ⇒ intElements.add(i)
       case l: Long   ⇒ longElements.add(l)
@@ -144,7 +144,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
     val intElements = new ArrayList[rd.ORSet.IntEntry]
     val longElements = new ArrayList[rd.ORSet.LongEntry]
     val otherElements = new ArrayList[rd.ORSet.OtherEntry]
-    orset.elements.foreach {
+    orset.elements foreach {
       case (s: String, dot) ⇒
         stringElements.add(rd.ORSet.StringEntry.newBuilder().setElement(s).setDot(vectorClockToProto(dot)).build())
       case (i: Int, dot) ⇒
@@ -247,7 +247,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
 
   def vectorClockToProto(vectorClock: VectorClock): rd.VectorClock = {
     val b = rd.VectorClock.newBuilder()
-    vectorClock.versions.foreach {
+    vectorClock.versions foreach {
       case (node, value) ⇒ b.addEntries(rd.VectorClock.Entry.newBuilder().
         setNode(uniqueAddressToProto(node)).setClock(value))
     }

--- a/src/multi-jvm/scala/akka/contrib/datareplication/JepsenInspiredInsertSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/JepsenInspiredInsertSpec.scala
@@ -58,7 +58,7 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
   //  val totalCount = 2000
   val expectedData = (0 until totalCount).toSet
   val data: Map[RoleName, Seq[Int]] = {
-    val nodeIndex = nodes.zipWithIndex.map { case (n, i) => i -> n }.toMap
+    val nodeIndex = (nodes.zipWithIndex map { case (n, i) => i -> n }).toMap
     (0 until totalCount).groupBy(i => nodeIndex(i % nodeCount))
   }
   lazy val myData: Seq[Int] = data(myself)
@@ -88,7 +88,7 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
 
     "setup cluster" in {
       runOn(nodes: _*) {
-        nodes.foreach { join(_, n1) }
+        nodes foreach { join(_, n1) }
 
         within(10.seconds) {
           awaitAssert {
@@ -99,7 +99,7 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
       }
 
       runOn(controller) {
-        nodes.foreach { n => enterBarrier(n.name + "-joined") }
+        nodes foreach { n => enterBarrier(n.name + "-joined") }
       }
 
       enterBarrier("after-setup")
@@ -115,8 +115,8 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
         replicator.tell(Update(key, ORSet(), WriteOne, timeout, Some(i))(_ + i), writeProbe.ref)
         writeProbe.receiveOne(3.seconds)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure => fail }
+      val successWriteAcks = writeAcks collect { case success: UpdateSuccess => success }
+      val failureWriteAcks = writeAcks collect { case fail: UpdateFailure => fail }
       successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
       successWriteAcks.size should be(myData.size)
       failureWriteAcks should be(Nil)
@@ -146,8 +146,8 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
         replicator.tell(Update(key, ORSet(), WriteQuorum, timeout, Some(i))(_ + i), writeProbe.ref)
         writeProbe.receiveOne(timeout + 1.second)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure => fail }
+      val successWriteAcks = writeAcks collect { case success: UpdateSuccess => success }
+      val failureWriteAcks = writeAcks collect { case fail: UpdateFailure => fail }
       successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
       successWriteAcks.size should be(myData.size)
       failureWriteAcks should be(Nil)
@@ -190,8 +190,8 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
         replicator.tell(Update(key, ORSet(), WriteOne, timeout, Some(i))(_ + i), writeProbe.ref)
         writeProbe.receiveOne(3.seconds)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure => fail }
+      val successWriteAcks = writeAcks collect { case success: UpdateSuccess => success }
+      val failureWriteAcks = writeAcks collect { case fail: UpdateFailure => fail }
       successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
       successWriteAcks.size should be(myData.size)
       failureWriteAcks should be(Nil)
@@ -233,8 +233,8 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
         replicator.tell(Update(key, ORSet(), WriteQuorum, timeout, Some(i))(_ + i), writeProbe.ref)
         writeProbe.receiveOne(timeout + 1.second)
       }
-      val successWriteAcks = writeAcks.collect { case success: UpdateSuccess => success }
-      val failureWriteAcks = writeAcks.collect { case fail: UpdateFailure => fail }
+      val successWriteAcks = writeAcks collect { case success: UpdateSuccess => success }
+      val failureWriteAcks = writeAcks collect { case fail: UpdateFailure => fail }
       runOn(n1, n4, n5) {
         successWriteAcks.map(_.request.get).toSet should be(myData.toSet)
         successWriteAcks.size should be(myData.size)

--- a/src/multi-jvm/scala/akka/contrib/datareplication/PerformanceSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/PerformanceSpec.scala
@@ -121,7 +121,7 @@ class PerformanceSpec extends MultiNodeSpec(PerformanceSpec) with STMultiNodeSpe
   "Performance" must {
 
     "setup cluster" in {
-      roles.foreach { join(_, n1) }
+      roles foreach { join(_, n1) }
 
       within(10.seconds) {
         awaitAssert {

--- a/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatedShoppingCartSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatedShoppingCartSpec.scala
@@ -61,7 +61,7 @@ class ShoppingCart(userId: String) extends Actor with Stash {
       replicator ! Get(DataKey, ReadQuorum, timeout, Some(sender()))
 
     case GetSuccess(DataKey, data: LWWMap, Some(replyTo: ActorRef)) ⇒
-      val cart = Cart(data.entries.values.map { case line: LineItem ⇒ line }.toSet)
+      val cart = Cart((data.entries.values map { case line: LineItem ⇒ line }).toSet)
       replyTo ! cart
 
     case NotFound(DataKey, Some(replyTo: ActorRef)) ⇒


### PR DESCRIPTION
- Use infix notation for higher-order functions, as recommended
  in the style guide
  http://docs.scala-lang.org/style/method-invocation.html#higher-order-functions
