### PR TITLE
Remove defaults for ReadConsistency and WriteConsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ class DataBot extends Actor with ActorLogging {
       if (ThreadLocalRandom.current().nextBoolean()) {
         // add
         log.info("Adding: {}", s)
-        replicator ! Update("key", ORSet())(_ + s)
+        replicator ! Update("key", ORSet(), WriteLocal)(_ + s)
       } else {
         // remove
         log.info("Removing: {}", s)
-        replicator ! Update("key", ORSet())(_ - s)
+        replicator ! Update("key", ORSet(), WriteLocal)(_ - s)
       }
 
-    case _: UpdateResponse => // ignore  
+    case _: UpdateResponse => // ignore
 
     case Changed("key", data: ORSet) =>
       log.info("Current elements: {}", data.value)

--- a/src/test/scala/akka/contrib/datareplication/LocalConcurrencySpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/LocalConcurrencySpec.scala
@@ -28,7 +28,7 @@ object LocalConcurrencySpec {
 
     def receive = {
       case s: String =>
-        val update = Replicator.Update(key, ORSet.empty)(_ + s)
+        val update = Replicator.Update(key, ORSet.empty, Replicator.WriteLocal)(_ + s)
         replicator ! update
     }
   }
@@ -66,7 +66,7 @@ class LocalConcurrencySpec(_system: ActorSystem) extends TestKit(_system)
 
       val expected = ((1 to numMessages).map("a" + _) ++ (1 to numMessages).map("b" + _)).toSet
       awaitAssert {
-        replicator ! Replicator.Get("key")
+        replicator ! Replicator.Get("key", Replicator.ReadLocal)
         val ORSet(elements) = expectMsgType[Replicator.GetSuccess].data
         elements should be(expected)
       }

--- a/src/test/scala/akka/contrib/datareplication/protobuf/ReplicatorMessageSerializerSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/protobuf/ReplicatorMessageSerializerSpec.scala
@@ -48,8 +48,8 @@ class ReplicatorMessageSerializerSpec extends TestKit(ActorSystem("ReplicatorMes
       val ref1 = system.actorOf(Props.empty, "ref1")
       val data1 = GSet() + "a"
 
-      checkSerialization(Get("A"))
-      checkSerialization(Get("A", ReadQuorum, 2.seconds, Some("x")))
+      checkSerialization(Get("A", ReadLocal))
+      checkSerialization(Get("A", ReadQuorum(2.seconds), Some("x")))
       checkSerialization(GetSuccess("A", data1, None))
       checkSerialization(GetSuccess("A", data1, Some("x")))
       checkSerialization(NotFound("A", Some("x")))

--- a/src/test/scala/akka/contrib/datareplication/sample/DataBot.scala
+++ b/src/test/scala/akka/contrib/datareplication/sample/DataBot.scala
@@ -35,12 +35,12 @@ object DataBot {
                 port = 0
               }
             }
-            
+
             akka.cluster {
               seed-nodes = [
                 "akka.tcp://ClusterSystem@127.0.0.1:2551",
                 "akka.tcp://ClusterSystem@127.0.0.1:2552"]
-            
+
               auto-down-unreachable-after = 10s
             }
             """)))
@@ -75,14 +75,14 @@ class DataBot extends Actor with ActorLogging {
       if (ThreadLocalRandom.current().nextBoolean()) {
         // add
         log.info("Adding: {}", s)
-        replicator ! Update("key", ORSet())(_ + s)
+        replicator ! Update("key", ORSet(), WriteLocal)(_ + s)
       } else {
         // remove
         log.info("Removing: {}", s)
-        replicator ! Update("key", ORSet())(_ - s)
+        replicator ! Update("key", ORSet(), WriteLocal)(_ - s)
       }
 
-    case _: UpdateResponse => // ignore  
+    case _: UpdateResponse => // ignore
 
     case Changed("key", data: ORSet) =>
       log.info("Current elements: {}", data.value)


### PR DESCRIPTION
- Removed constructors/apply with default value (ReadOne/WriteOne) for consistency in
  Get, Update and Delete messages
- The reason is that there is no good default. It depends, and is something that should
  be thought of by the user.
- WriteOne renamed to WriteLocal
- ReadOne renamed to ReadLocal
- WriteTwo and WriteThree removed, in favor of WriteTo(n)
- ReadTwo and ReadThree removed, in favor of ReadFrom(n)
- timeout parameter moved to ReadConsistency and WriteConsistency class.
  It is not appropriate for WriteLocal/ReadLocal.
  This also simplified the API.

Fixes #47 
