### PR TITLE
Abort Update if specified readConsistency fails

### DIFF
--- a/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorSpec.scala
@@ -424,6 +424,14 @@ class ReplicatorSpec extends MultiNodeSpec(ReplicatorSpec) with STMultiNodeSpec 
     }
     enterBarrier("quorum-update-from-second")
 
+    runOn(first, second) {
+      replicator ! Update("E2", GCounter(), readAll, writeAll, Some(999))(_ + 1)
+      expectMsg(ReadFailure("E2", Some(999)))
+      replicator ! Get("E2", ReadLocal)
+      expectMsg(NotFound("E2", None))
+    }
+    enterBarrier("read-all-fail-update")
+
     runOn(first) {
       testConductor.passThrough(first, third, Direction.Both).await
       testConductor.passThrough(second, third, Direction.Both).await


### PR DESCRIPTION
- Changed behavior for Update with readConsistency != ReadLocal
  If the read fails the update will now be aborted and replied
  with ReadFailure. Previously it continued with the local value.
- I think I was able to recollect the reason why I implemented it the other way. I had the ShoppingCart use case in mind and wanted to have an easy way to do an best effort ReadQuorum/WriteQuorum with fallback to local value if the ReadQuorum fails. I think the use case @hseeberger had in mind is more useful. We could support both, but I don't want to add more variants than really needed.

Fixes #50 
