### PR TITLE
Use Scala 2.11 as default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ import generate.protobuf._
 
 val akkaVersion = "2.3.6"
 
-
 val project = Project(
   id = "akka-data-replication",
   base = file("."),
@@ -13,8 +12,8 @@ val project = Project(
     name := "akka-data-replication",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
     version := "0.8-SNAPSHOT",
-    scalaVersion := "2.10.4",
-    crossScalaVersions := Seq("2.10.4", "2.11.2"),
+    scalaVersion := "2.11.4",
+    crossScalaVersions := Seq("2.10.4", "2.11.4"),
     // compile options
     scalacOptions in compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint"),
     javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation"),
@@ -29,6 +28,16 @@ val project = Project(
       "com.typesafe.akka" %% "akka-cluster" % akkaVersion,
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % "test",
       "org.scalatest" %% "scalatest" % "2.1.3" % "test"),
+    // add scala-xml dependency when needed (for Scala 2.11 and newer) in a robust way
+    // this mechanism supports cross-version publishing
+    libraryDependencies := {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        // if scala 2.11+ is used, add dependency on scala-xml module (needed for scalatest)
+        case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+          libraryDependencies.value ++ Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.1" % "test")
+        case _ => libraryDependencies.value
+      }
+    }, 
     // make sure that MultiJvm test are compiled by the default test compilation
     compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in Test),
     // disable parallel tests
@@ -48,5 +57,7 @@ val project = Project(
     }
   )
 ) configs (MultiJvm)
+
+
 
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.5

--- a/src/main/scala/akka/contrib/datareplication/Replicator.scala
+++ b/src/main/scala/akka/contrib/datareplication/Replicator.scala
@@ -200,11 +200,30 @@ object Replicator {
     /**
      * Retrieve value from other replicas with given `readConsistency` and then modify value and
      * replicate with given `writeConsistency`.
+     *
+     * If there is no current data value for the `key` the `initial` value will be
+     * passed to the `modify` function.
+     *
+     * The optional `request` context is included in the reply messages. This is a convenient
+     * way to pass contextual information (e.g. original sender) without having to use `ask`
+     * or local correlation data structures.
      */
     def apply[A <: ReplicatedData](
       key: String, initial: A, readConsistency: ReadConsistency, writeConsistency: WriteConsistency,
-      request: Option[Any] = None)(modify: A => A): Update[A] =
+      request: Option[Any])(modify: A => A): Update[A] =
       Update(key, readConsistency, writeConsistency, request)(modifyWithInitial(initial, modify))
+
+    /**
+     * Retrieve value from other replicas with given `readConsistency` and then modify value and
+     * replicate with given `writeConsistency`.
+     *
+     * If there is no current data value for the `key` the `initial` value will be
+     * passed to the `modify` function.
+     */
+    def apply[A <: ReplicatedData](
+      key: String, initial: A, readConsistency: ReadConsistency, writeConsistency: WriteConsistency)(
+        modify: A => A): Update[A] =
+      Update(key, readConsistency, writeConsistency, None)(modifyWithInitial(initial, modify))
 
     private def modifyWithInitial[A <: ReplicatedData](initial: A, modify: A => A): Option[A] => A = {
       case Some(data) => modify(data)


### PR DESCRIPTION
- Improve cross build, so that test can be run with both 2.10 and 2.11
- Issue with multiple overloaded methods with default arguments,
  2.10 did not complain (strange)
- sbt 0.13.5
