### PR TITLE
Disallow ORMap.put for replacing ORSet, add ORMap.updated

### DIFF
--- a/src/main/scala/akka/contrib/datareplication/LWWMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/LWWMap.scala
@@ -67,11 +67,15 @@ case class LWWMap(
 
   /**
    * Removes an entry from the map.
+   * Note that if there is a conflicting update on another node the entry will
+   * not be removed after merge.
    */
   def -(key: String)(implicit node: Cluster): LWWMap = remove(node, key)
 
   /**
    * Removes an entry from the map.
+   * Note that if there is a conflicting update on another node the entry will
+   * not be removed after merge.
    */
   def remove(node: Cluster, key: String): LWWMap =
     copy(underlying.remove(node, key))

--- a/src/main/scala/akka/contrib/datareplication/ORMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/ORMap.scala
@@ -51,6 +51,10 @@ case class ORMap(
 
   def getOrElse(key: String, default: => ReplicatedData): ReplicatedData = values.getOrElse(key, default)
 
+  def contains(key: String): Boolean = values.contains(key)
+
+  def isEmpty: Boolean = values.isEmpty
+
   /**
    * Adds an entry to the map
    */
@@ -60,7 +64,17 @@ case class ORMap(
   }
 
   /**
-   * Adds an entry to the map
+   * Adds an entry to the map.
+   * Note that the new `value` will be merged with existing values
+   * on other nodes and the outcome depends on what `ReplicatedData`
+   * type that is used.
+   *
+   * Consider using [[#updated]] instead of `put` if you want modify
+   * existing entry.
+   *
+   * `IllegalArgumentException` is thrown if you try to replace an existing `ORSet`
+   * value, because important history can be lost when replacing the `ORSet` and
+   * undesired effects of merging will occur. Use [[ORMultiMap]] or [[#updated]] instead.
    */
   def put(node: Cluster, key: String, value: ReplicatedData): ORMap = put(node.selfUniqueAddress, key, value)
 
@@ -68,23 +82,63 @@ case class ORMap(
    * INTERNAL API
    */
   private[akka] def put(node: UniqueAddress, key: String, value: ReplicatedData): ORMap =
-    ORMap(keys.add(node, key), values.updated(key, value))
+    if (value.isInstanceOf[ORSet] && values.contains(key))
+      throw new IllegalArgumentException(
+        "`ORMap.put` must not be used to replace an existing `ORSet` " +
+          "value, because important history can be lost when replacing the `ORSet` and " +
+          "undesired effects of merging will occur. Use `ORMultiMap` or `ORMap.updated` instead.")
+    else
+      ORMap(keys.add(node, key), values.updated(key, value))
+
+  /**
+   * Scala API: Replace a value by applying the `modify` function on the existing value.
+   *
+   * If there is no current value for the `key` the `initial` value will be
+   * passed to the `modify` function.
+   */
+  def updated[A <: ReplicatedData](node: Cluster, key: String, initial: A)(modify: A => A): ORMap =
+    updated(node.selfUniqueAddress, key, initial)(modify)
+
+  /**
+   * Java API: Replace a value by applying the `modify` function on the existing value.
+   *
+   * If there is no current value for the `key` the `initial` value will be
+   * passed to the `modify` function.
+   */
+  def updated[A <: ReplicatedData](node: Cluster, key: String, initial: A, modify: akka.japi.Function[A, A]): ORMap =
+    updated(node, key, initial)(value => modify.apply(value))
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def updated[A <: ReplicatedData](node: UniqueAddress, key: String, initial: A)(modify: A => A): ORMap = {
+    val newValue = values.get(key) match {
+      case Some(old) => modify(old.asInstanceOf[A])
+      case _         => modify(initial)
+    }
+    ORMap(keys.add(node, key), values.updated(key, newValue))
+  }
 
   /**
    * Removes an entry from the map.
+   * Note that if there is a conflicting update on another node the entry will
+   * not be removed after merge.
    */
   def -(key: String)(implicit node: Cluster): ORMap = remove(node, key)
 
   /**
    * Removes an entry from the map.
+   * Note that if there is a conflicting update on another node the entry will
+   * not be removed after merge.
    */
   def remove(node: Cluster, key: String): ORMap = remove(node.selfUniqueAddress, key)
 
   /**
    * INTERNAL API
    */
-  private[akka] def remove(node: UniqueAddress, key: String): ORMap =
+  private[akka] def remove(node: UniqueAddress, key: String): ORMap = {
     ORMap(keys.remove(node, key), values - key)
+  }
 
   override def merge(that: ORMap): ORMap = {
     val mergedKeys = keys.merge(that.keys)

--- a/src/main/scala/akka/contrib/datareplication/ORSet.scala
+++ b/src/main/scala/akka/contrib/datareplication/ORSet.scala
@@ -146,6 +146,8 @@ case class ORSet(
 
   def contains(a: Any): Boolean = elements.contains(a)
 
+  def isEmpty: Boolean = elements.isEmpty
+
   /**
    * Adds an element to the set
    */
@@ -180,6 +182,16 @@ case class ORSet(
    */
   private[akka] def remove(node: UniqueAddress, element: Any): ORSet =
     copy(elements = elements - element)
+
+  /**
+   * Removes all elements from the set, but keeps the history.
+   */
+  def clear(node: Cluster): ORSet = clear(node.selfUniqueAddress)
+
+  /**
+   * INTERNAL API
+   */
+  private[akka] def clear(node: UniqueAddress): ORSet = copy(elements = Map.empty)
 
   /**
    * When element is in this Set but not in that Set:

--- a/src/main/scala/akka/contrib/datareplication/VectorClock.scala
+++ b/src/main/scala/akka/contrib/datareplication/VectorClock.scala
@@ -57,6 +57,7 @@ object VectorClock {
   private object Timestamp {
     final val Zero = 0L
     final val EndMarker = Long.MinValue
+    val counter = new AtomicLong(1L)
   }
 
   /**
@@ -105,10 +106,8 @@ final case class VectorClock(
    * INTERNAL API
    * Increment the version for the node passed as argument. Returns a new VectorClock.
    */
-  private[akka] def increment(node: UniqueAddress): VectorClock = {
-    val currentTimestamp = versions.getOrElse(node, Timestamp.Zero)
-    copy(versions = versions.updated(node, currentTimestamp + 1))
-  }
+  private[akka] def increment(node: UniqueAddress): VectorClock =
+    copy(versions = versions.updated(node, Timestamp.counter.getAndIncrement()))
 
   /**
    * Returns true if <code>this</code> and <code>that</code> are concurrent else false.

--- a/src/test/scala/akka/contrib/datareplication/PNCounterMapSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/PNCounterMapSpec.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.contrib.datareplication
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import akka.actor.Address
+import akka.cluster.UniqueAddress
+
+class PNCounterMapSpec extends WordSpec with Matchers {
+
+  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2)
+
+  "A PNCounterMap" must {
+
+    "be able to increment and decrement entries" in {
+      val m = PNCounterMap().increment(node1, "a", 2).increment(node1, "b", 3).decrement(node2, "a", 1)
+      m.entries should be(Map("a" -> 1, "b" -> 3))
+    }
+
+    "be able to have its entries correctly merged with another ORMap with other entries" in {
+      val m1 = PNCounterMap().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
+      val m2 = PNCounterMap().increment(node2, "c", 5)
+
+      // merge both ways
+      val expected = Map("a" -> 1, "b" -> 3, "c" -> 7)
+      (m1 merge m2).entries should be(expected)
+      (m2 merge m1).entries should be(expected)
+    }
+
+    "be able to remove entry" in {
+      val m1 = PNCounterMap().increment(node1, "a", 1).increment(node1, "b", 3).increment(node1, "c", 2)
+      val m2 = PNCounterMap().increment(node2, "c", 5)
+
+      val merged1 = m1 merge m2
+
+      val m3 = merged1.remove(node1, "b")
+      (merged1 merge m3).entries should be(Map("a" -> 1, "c" -> 7))
+
+      // but if there is a conflicting update the entry is not removed
+      val m4 = merged1.increment(node2, "b", 10)
+      (m3 merge m4).entries should be(Map("a" -> 1, "b" -> 13, "c" -> 7))
+    }
+
+  }
+}

--- a/src/test/scala/akka/contrib/datareplication/protobuf/ReplicatedDataSerializerSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/protobuf/ReplicatedDataSerializerSpec.scala
@@ -82,13 +82,13 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem("ReplicatedDataSe
       checkSerialization(ORSet().add(address1, 1L).add(address2, 2L))
       checkSerialization(ORSet().add(address1, "a").add(address2, 2).add(address3, 3L).add(address3, address3))
 
-      checkSameContent(
-        ORSet().add(address1, "a").add(address2, "b"),
-        ORSet().add(address2, "b").add(address1, "a"))
+      val s1 = ORSet().add(address1, "a").add(address2, "b")
+      val s2 = ORSet().add(address2, "b").add(address1, "a")
+      checkSameContent(s1.merge(s2), s2.merge(s1))
 
-      checkSameContent(
-        ORSet().add(address1, "a").add(address2, 17).remove(address3, 17),
-        ORSet().add(address2, 17).remove(address3, 17).add(address1, "a"))
+      val s3 = ORSet().add(address1, "a").add(address2, 17).remove(address3, 17)
+      val s4 = ORSet().add(address2, 17).remove(address3, 17).add(address1, "a")
+      checkSameContent(s3.merge(s4), s4.merge(s3))
     }
 
     "serialize Flag" in {
@@ -173,12 +173,9 @@ class ReplicatedDataSerializerSpec extends TestKit(ActorSystem("ReplicatedDataSe
       checkSerialization(VectorClock().increment(address1))
       checkSerialization(VectorClock().increment(address1).increment(address2))
 
-      checkSameContent(
-        VectorClock().increment(address1).increment(address2).increment(address1),
-        VectorClock().increment(address2).increment(address1).increment(address1))
-      checkSameContent(
-        VectorClock().increment(address1).increment(address3),
-        VectorClock().increment(address3).increment(address1))
+      val v1 = VectorClock().increment(address1).increment(address1)
+      val v2 = VectorClock().increment(address2)
+      checkSameContent(v1.merge(v2), v2.merge(v1))
     }
 
   }


### PR DESCRIPTION
* add tests to illustrate the issue
* throw exception if ORMap.put is used for replacing existing
  ORSet value
* add a new `updated` method that should be used for modifying
  and entry
* add docs to clarify

Refs #60 