### PR TITLE
Improve unapply

### DIFF
--- a/src/main/scala/akka/contrib/datareplication/Flag.scala
+++ b/src/main/scala/akka/contrib/datareplication/Flag.scala
@@ -4,28 +4,29 @@
 package akka.contrib.datareplication
 
 object Flag {
+  /**
+   * `Flag` that is initialized to `false`.
+   */
   val empty = new Flag(false)
   def apply(): Flag = empty
   /**
-   * Java API
+   * Java API: `Flag` that is initialized to `false`.
    */
   def create(): Flag = empty
 
-  def unapply(value: Any): Option[Boolean] = value match {
-    case f: Flag ⇒ Some(f.value)
-    case _       ⇒ None
-  }
+  // unapply from case class
 }
 
 /**
  * Implements a boolean flag CRDT that is initialized to `false` and
  * can be switched to `true`. `true` wins over `false` in merge.
+ *
+ * This class is immutable, i.e. "modifying" methods return a new instance.
  */
+@SerialVersionUID(1L)
 final case class Flag(enabled: Boolean) extends ReplicatedData with ReplicatedDataSerialization {
 
   type T = Flag
-
-  def value: Boolean = enabled
 
   def switchOn: Flag =
     if (enabled) this

--- a/src/main/scala/akka/contrib/datareplication/GSet.scala
+++ b/src/main/scala/akka/contrib/datareplication/GSet.scala
@@ -12,10 +12,7 @@ object GSet {
    */
   def create[A](): GSet[A] = empty[A]
 
-  def unapply(value: Any): Option[Set[Any]] = value match {
-    case s: GSet[Any] @unchecked ⇒ Some(s.value)
-    case _                       ⇒ None
-  }
+  // unapply from case class
 }
 
 /**
@@ -23,22 +20,20 @@ object GSet {
  * remove an element of a G-Set.
  *
  * A G-Set doesn't accumulate any garbage apart from the elements themselves.
+ *
+ * This class is immutable, i.e. "modifying" methods return a new instance.
  */
+@SerialVersionUID(1L)
 final case class GSet[A](elements: Set[A]) extends ReplicatedData with ReplicatedDataSerialization {
 
   type T = GSet[A]
 
   /**
-   * Scala API
-   */
-  def value: Set[A] = elements
-
-  /**
    * Java API
    */
-  def getValue(): java.util.Set[A] = {
+  def getElements(): java.util.Set[A] = {
     import scala.collection.JavaConverters._
-    value.asJava
+    elements.asJava
   }
 
   def contains(a: A): Boolean = elements(a)

--- a/src/main/scala/akka/contrib/datareplication/ORMap.scala
+++ b/src/main/scala/akka/contrib/datareplication/ORMap.scala
@@ -5,6 +5,7 @@ package akka.contrib.datareplication
 
 import akka.cluster.Cluster
 import akka.cluster.UniqueAddress
+import akka.util.HashCode
 
 object ORMap {
   private val _empty: ORMap[ReplicatedData] = new ORMap(ORSet.empty, Map.empty)
@@ -15,20 +16,23 @@ object ORMap {
    */
   def create[A <: ReplicatedData](): ORMap[A] = empty[A]
 
-  def unapply(value: Any): Option[Map[String, ReplicatedData]] = value match {
-    case r: ORMap[ReplicatedData] @unchecked ⇒ Some(r.entries)
-    case _                                   ⇒ None
-  }
+  /**
+   * Extract the [[ORMap#elements]].
+   */
+  def unapply[A <: ReplicatedData](m: ORMap[A]): Option[Map[String, A]] = Some(m.entries)
+
 }
 
 /**
  * Implements a 'Observed Remove Map' CRDT, also called a 'OR-Map'.
  *
- * It has similar semantics as an [[ORSet]], but in case
- * concurrent updates the values are merged, and must therefore be [[ReplicatedData]]
- * themselves.
+ * It has similar semantics as an [[ORSet]], but in case of concurrent updates
+ * the values are merged, and must therefore be [[ReplicatedData]] types themselves.
+ *
+ * This class is immutable, i.e. "modifying" methods return a new instance.
  */
-final case class ORMap[A <: ReplicatedData](
+@SerialVersionUID(1L)
+final class ORMap[A <: ReplicatedData] private[akka] (
   private[akka] val keys: ORSet[String],
   private[akka] val values: Map[String, A])
   extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
@@ -36,12 +40,12 @@ final case class ORMap[A <: ReplicatedData](
   type T = ORMap[A]
 
   /**
-   * Scala API
+   * Scala API: All entries of the map.
    */
   def entries: Map[String, A] = values
 
   /**
-   * Java API
+   * Java API: All entries of the map.
    */
   def getEntries(): java.util.Map[String, A] = {
     import scala.collection.JavaConverters._
@@ -50,6 +54,10 @@ final case class ORMap[A <: ReplicatedData](
 
   def get(key: String): Option[A] = values.get(key)
 
+  /**
+   * Scala API: Get the value associated with the key if there is one,
+   * else return the given default.
+   */
   def getOrElse(key: String, default: => A): A = values.getOrElse(key, default)
 
   def contains(key: String): Boolean = values.contains(key)
@@ -58,6 +66,7 @@ final case class ORMap[A <: ReplicatedData](
 
   /**
    * Adds an entry to the map
+   * @see [[#put]]
    */
   def +(entry: (String, A))(implicit node: Cluster): ORMap[A] = {
     val (key, value) = entry
@@ -89,7 +98,7 @@ final case class ORMap[A <: ReplicatedData](
           "value, because important history can be lost when replacing the `ORSet` and " +
           "undesired effects of merging will occur. Use `ORMultiMap` or `ORMap.updated` instead.")
     else
-      ORMap(keys.add(node, key), values.updated(key, value))
+      new ORMap(keys.add(node, key), values.updated(key, value))
 
   /**
    * Scala API: Replace a value by applying the `modify` function on the existing value.
@@ -117,7 +126,7 @@ final case class ORMap[A <: ReplicatedData](
       case Some(old) => modify(old)
       case _         => modify(initial)
     }
-    ORMap(keys.add(node, key), values.updated(key, newValue))
+    new ORMap(keys.add(node, key), values.updated(key, newValue))
   }
 
   /**
@@ -138,13 +147,13 @@ final case class ORMap[A <: ReplicatedData](
    * INTERNAL API
    */
   private[akka] def remove(node: UniqueAddress, key: String): ORMap[A] = {
-    ORMap(keys.remove(node, key), values - key)
+    new ORMap(keys.remove(node, key), values - key)
   }
 
   override def merge(that: ORMap[A]): ORMap[A] = {
     val mergedKeys = keys.merge(that.keys)
     var mergedValues = Map.empty[String, A]
-    mergedKeys.elements.keysIterator.foreach {
+    mergedKeys.elementsMap.keysIterator.foreach {
       case key: String ⇒
         (this.values.get(key), that.values.get(key)) match {
           case (Some(thisValue), Some(thatValue)) ⇒
@@ -163,7 +172,7 @@ final case class ORMap[A <: ReplicatedData](
         }
     }
 
-    ORMap(mergedKeys, mergedValues)
+    new ORMap(mergedKeys, mergedValues)
   }
 
   override def needPruningFrom(removedNode: UniqueAddress): Boolean = {
@@ -180,7 +189,7 @@ final case class ORMap[A <: ReplicatedData](
         acc.updated(key, data.prune(removedNode, collapseInto).asInstanceOf[A])
       case (acc, _) ⇒ acc
     }
-    ORMap(prunedKeys, prunedValues)
+    new ORMap(prunedKeys, prunedValues)
   }
 
   override def pruningCleanup(removedNode: UniqueAddress): ORMap[A] = {
@@ -190,7 +199,24 @@ final case class ORMap[A <: ReplicatedData](
         acc.updated(key, data.pruningCleanup(removedNode).asInstanceOf[A])
       case (acc, _) ⇒ acc
     }
-    ORMap(pruningCleanupedKeys, pruningCleanupedValues)
+    new ORMap(pruningCleanupedKeys, pruningCleanupedValues)
   }
+
+  // this class cannot be a `case class` because we need different `unapply`
+
+  override def toString: String = s"OR$entries"
+
+  override def equals(o: Any): Boolean = o match {
+    case other: ORMap[_] => keys == other.keys && values == other.values
+    case _               => false
+  }
+
+  override def hashCode: Int = {
+    var result = HashCode.SEED
+    result = HashCode.hash(result, keys)
+    result = HashCode.hash(result, values)
+    result
+  }
+
 }
 

--- a/src/main/scala/akka/contrib/datareplication/ReplicatedData.scala
+++ b/src/main/scala/akka/contrib/datareplication/ReplicatedData.scala
@@ -19,6 +19,9 @@ import akka.cluster.UniqueAddress
  * for creating message digests (SHA-1) to detect changes. Therefore it is
  * important that the serialization produce the same bytes for the same content.
  * For example sets and maps should be sorted deterministically in the serialization.
+ *
+ * ReplicatedData types should be immutable, i.e. "modifying" methods should return
+ * a new instance.
  */
 trait ReplicatedData {
   type T <: ReplicatedData
@@ -35,7 +38,7 @@ trait ReplicatedData {
  * Java.
  */
 abstract class AbstractReplicatedData extends ReplicatedData {
-  // it is not possible to use a more strict type, because it is erased somehow, and 
+  // it is not possible to use a more strict type, because it is erased somehow, and
   // the implementation is anyway required to implement
   // merge(that: ReplicatedData): ReplicatedData
   type T = AbstractReplicatedData

--- a/src/main/scala/akka/contrib/datareplication/VectorClock.scala
+++ b/src/main/scala/akka/contrib/datareplication/VectorClock.scala
@@ -17,7 +17,7 @@ import akka.cluster.UniqueAddress
  */
 object VectorClock {
 
-  val empty: VectorClock = new VectorClock
+  val empty: VectorClock = new VectorClock(TreeMap.empty[UniqueAddress, Long])
   def apply(): VectorClock = empty
   /**
    * Java API
@@ -76,10 +76,12 @@ object VectorClock {
  * }}}
  *
  * Based on code from `akka.cluster.VectorClock`.
+ *
+ * This class is immutable, i.e. "modifying" methods return a new instance.
  */
 @SerialVersionUID(1L)
-final case class VectorClock(
-  private[akka] val versions: TreeMap[UniqueAddress, Long] = TreeMap.empty[UniqueAddress, Long])
+final case class VectorClock private[akka] (
+  private[akka] val versions: TreeMap[UniqueAddress, Long])
   extends ReplicatedData with ReplicatedDataSerialization with RemovedNodePruning {
 
   type T = VectorClock

--- a/src/main/scala/akka/contrib/datareplication/protobuf/ReplicatedDataSerializer.scala
+++ b/src/main/scala/akka/contrib/datareplication/protobuf/ReplicatedDataSerializer.scala
@@ -147,7 +147,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
     val intElements = new ArrayList[rd.ORSet.IntEntry]
     val longElements = new ArrayList[rd.ORSet.LongEntry]
     val otherElements = new ArrayList[rd.ORSet.OtherEntry]
-    orset.elements.foreach {
+    orset.elementsMap.foreach {
       case (s: String, dot) ⇒
         stringElements.add(rd.ORSet.StringEntry.newBuilder().setElement(s).setDot(vectorClockToProto(dot)).build())
       case (i: Int, dot) ⇒
@@ -187,7 +187,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
         orset.getLongElementsList.iterator.asScala.map(e ⇒ e.getElement -> vectorClockFromProto(e.getDot)) ++
         orset.getOtherElementsList.iterator.asScala.map(e ⇒
           otherMessageFromProto(e.getElement) -> vectorClockFromProto(e.getDot))
-    ORSet(elements = entries.toMap, vclock = vectorClockFromProto(orset.getVclock))
+    new ORSet(elementsMap = entries.toMap, vclock = vectorClockFromProto(orset.getVclock))
   }
 
   def flagToProto(flag: Flag): rd.Flag =
@@ -210,7 +210,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
     lwwRegisterFromProto(rd.LWWRegister.parseFrom(bytes))
 
   def lwwRegisterFromProto(lwwRegister: rd.LWWRegister): LWWRegister[Any] =
-    LWWRegister(
+    new LWWRegister(
       uniqueAddressFromProto(lwwRegister.getNode),
       otherMessageFromProto(lwwRegister.getState),
       lwwRegister.getTimestamp)
@@ -228,7 +228,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
     gcounterFromProto(rd.GCounter.parseFrom(bytes))
 
   def gcounterFromProto(gcounter: rd.GCounter): GCounter = {
-    GCounter(state = gcounter.getEntriesList.asScala.map(entry ⇒
+    new GCounter(state = gcounter.getEntriesList.asScala.map(entry ⇒
       uniqueAddressFromProto(entry.getNode) -> entry.getValue)(breakOut))
   }
 
@@ -242,7 +242,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
     pncounterFromProto(rd.PNCounter.parseFrom(bytes))
 
   def pncounterFromProto(pncounter: rd.PNCounter): PNCounter = {
-    PNCounter(
+    new PNCounter(
       increments = gcounterFromProto(pncounter.getIncrements),
       decrements = gcounterFromProto(pncounter.getDecrements))
   }
@@ -279,7 +279,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
   def ormapFromProto(ormap: rd.ORMap): ORMap[ReplicatedData] = {
     val entries = ormap.getEntriesList.asScala.map(entry ⇒
       entry.getKey -> otherMessageFromProto(entry.getValue).asInstanceOf[ReplicatedData]).toMap
-    ORMap(
+    new ORMap(
       keys = orsetFromProto(ormap.getKeys).asInstanceOf[ORSet[String]],
       entries)
   }
@@ -299,7 +299,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
   def lwwmapFromProto(lwwmap: rd.LWWMap): LWWMap[Any] = {
     val entries = lwwmap.getEntriesList.asScala.map(entry ⇒
       entry.getKey -> lwwRegisterFromProto(entry.getValue)).toMap
-    LWWMap(ORMap(
+    new LWWMap(new ORMap(
       keys = orsetFromProto(lwwmap.getKeys).asInstanceOf[ORSet[String]],
       entries))
   }
@@ -319,7 +319,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
   def pncountermapFromProto(pncountermap: rd.PNCounterMap): PNCounterMap = {
     val entries = pncountermap.getEntriesList.asScala.map(entry ⇒
       entry.getKey -> pncounterFromProto(entry.getValue)).toMap
-    PNCounterMap(ORMap(
+    new PNCounterMap(new ORMap(
       keys = orsetFromProto(pncountermap.getKeys).asInstanceOf[ORSet[String]],
       entries))
   }
@@ -339,7 +339,7 @@ class ReplicatedDataSerializer(val system: ExtendedActorSystem) extends Serializ
   def multimapFromProto(multimap: rd.ORMultiMap): ORMultiMap[Any] = {
     val entries = multimap.getEntriesList.asScala.map(entry ⇒
       entry.getKey -> orsetFromProto(entry.getValue)).toMap
-    ORMultiMap(ORMap(
+    new ORMultiMap(new ORMap(
       keys = orsetFromProto(multimap.getKeys).asInstanceOf[ORSet[String]],
       entries))
   }

--- a/src/multi-jvm/scala/akka/contrib/datareplication/JepsenInspiredInsertSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/JepsenInspiredInsertSpec.scala
@@ -128,7 +128,7 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
           val readProbe = TestProbe()
           replicator.tell(Get(key, ReadLocal), readProbe.ref)
           val result = readProbe.expectMsgPF() { case GetSuccess(key, set: ORSet[_], _) ⇒ set }
-          result.value should be(expectedData)
+          result.elements should be(expectedData)
         }
       }
 
@@ -161,8 +161,8 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
       val readProbe = TestProbe()
       replicator.tell(Get(key, readQuorum), readProbe.ref)
       val result = readProbe.expectMsgPF() { case GetSuccess(key, set: ORSet[_], _) ⇒ set }
-      val survivors = result.value.size
-      result.value should be(expectedData)
+      val survivors = result.elements.size
+      result.elements should be(expectedData)
 
     }
 
@@ -207,7 +207,7 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
           val readProbe = TestProbe()
           replicator.tell(Get(key, ReadLocal), readProbe.ref)
           val result = readProbe.expectMsgPF() { case GetSuccess(key, set: ORSet[_], _) ⇒ set }
-          result.value should be(expectedData)
+          result.elements should be(expectedData)
         }
       }
 
@@ -258,8 +258,8 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
         val readProbe = TestProbe()
         replicator.tell(Get(key, readQuorum), readProbe.ref)
         val result = readProbe.expectMsgPF() { case GetSuccess(key, set: ORSet[_], _) ⇒ set }
-        val survivors = result.value.size
-        result.value should be(expectedData)
+        val survivors = result.elements.size
+        result.elements should be(expectedData)
       }
       // but on the 3 node side, read from quorum doesn't mean that we are guaranteed to see
       // the writes from the other side, yet
@@ -270,7 +270,7 @@ class JepsenInspiredInsertSpec extends MultiNodeSpec(JepsenInspiredInsertSpec) w
           val readProbe = TestProbe()
           replicator.tell(Get(key, ReadLocal), readProbe.ref)
           val result = readProbe.expectMsgPF() { case GetSuccess(key, set: ORSet[_], _) ⇒ set }
-          result.value should be(expectedData)
+          result.elements should be(expectedData)
         }
       }
     }

--- a/src/multi-jvm/scala/akka/contrib/datareplication/PerformanceSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/PerformanceSpec.scala
@@ -113,7 +113,7 @@ class PerformanceSpec extends MultiNodeSpec(PerformanceSpec) with STMultiNodeSpe
         val readProbe = TestProbe()
         replicator.tell(Get(key, ReadLocal), readProbe.ref)
         val result = readProbe.expectMsgPF() { case GetSuccess(key, set: ORSet[Int] @unchecked, _) ⇒ set }
-        result.value should be(expectedData)
+        result.elements should be(expectedData)
       }
     }
   }

--- a/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorChaosSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorChaosSpec.scala
@@ -62,8 +62,8 @@ class ReplicatorChaosSpec extends MultiNodeSpec(ReplicatorChaosSpec) with STMult
         val value = expectMsgPF() {
           case GetSuccess(`key`, c: GCounter, _)  ⇒ c.value
           case GetSuccess(`key`, c: PNCounter, _) ⇒ c.value
-          case GetSuccess(`key`, c: GSet[_], _)   ⇒ c.value
-          case GetSuccess(`key`, c: ORSet[_], _)  ⇒ c.value
+          case GetSuccess(`key`, c: GSet[_], _)   ⇒ c.elements
+          case GetSuccess(`key`, c: ORSet[_], _)  ⇒ c.elements
         }
         value should be(expected)
       }

--- a/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorPruningSpec.scala
+++ b/src/multi-jvm/scala/akka/contrib/datareplication/ReplicatorPruningSpec.scala
@@ -93,7 +93,7 @@ class ReplicatorPruningSpec extends MultiNodeSpec(ReplicatorPruningSpec) with ST
 
       replicator ! Get("B", ReadLocal)
       val oldSet = expectMsgType[GetSuccess].data.asInstanceOf[ORSet[String]]
-      oldSet.value should be(Set("a", "b", "c"))
+      oldSet.elements should be(Set("a", "b", "c"))
 
       replicator ! Get("C", ReadLocal)
       val oldMap = expectMsgType[GetSuccess].data.asInstanceOf[PNCounterMap]
@@ -132,7 +132,7 @@ class ReplicatorPruningSpec extends MultiNodeSpec(ReplicatorPruningSpec) with ST
             replicator ! Get("B", ReadLocal)
             expectMsgPF() {
               case GetSuccess(_, s: ORSet[String] @unchecked, _) ⇒
-                s.value should be(Set("a", "b", "c"))
+                s.elements should be(Set("a", "b", "c"))
                 s.needPruningFrom(thirdUniqueAddress) should be(false)
             }
           }

--- a/src/multi-jvm/scala/sample/datareplication/ReplicatedServiceRegistrySpec.scala
+++ b/src/multi-jvm/scala/sample/datareplication/ReplicatedServiceRegistrySpec.scala
@@ -109,7 +109,7 @@ class ReplicatedServiceRegistry() extends Actor with ActorLogging {
       sender() ! Bindings(key, services.getOrElse(key, Set.empty))
 
     case Changed(KeysDataKey, data: GSet[String] @unchecked) =>
-      val newKeys = data.value
+      val newKeys = data.elements
       log.debug("Services changed, added: {}, all: {}", (newKeys -- keys), newKeys)
       (newKeys -- keys).foreach { dKey =>
         // subscribe to get notifications of when services with this name are added or removed
@@ -119,7 +119,7 @@ class ReplicatedServiceRegistry() extends Actor with ActorLogging {
 
     case Changed(dKey, data: ORSet[ActorRef] @unchecked) =>
       val name = dKey.split(":").tail.mkString
-      val newServices = data.value
+      val newServices = data.elements
       log.debug("Services changed for name [{}]: {}", name, newServices)
       services = services.updated(name, newServices)
       context.system.eventStream.publish(BindingChanged(name, newServices))

--- a/src/test/scala/akka/contrib/datareplication/FlagSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/FlagSpec.scala
@@ -6,6 +6,7 @@ package akka.contrib.datareplication
 
 import org.scalatest.WordSpec
 import org.scalatest.Matchers
+import akka.contrib.datareplication.Replicator.Changed
 
 class FlagSpec extends WordSpec with Matchers {
 
@@ -15,18 +16,29 @@ class FlagSpec extends WordSpec with Matchers {
       val f1 = Flag()
       val f2 = f1.switchOn
       val f3 = f2.switchOn
-      f1.value should be(false)
-      f2.value should be(true)
-      f3.value should be(true)
+      f1.enabled should be(false)
+      f2.enabled should be(true)
+      f3.enabled should be(true)
     }
 
     "merge by picking true" in {
       val f1 = Flag()
       val f2 = f1.switchOn
       val m1 = f1 merge f2
-      m1.value should be(true)
+      m1.enabled should be(true)
       val m2 = f2 merge f1
-      m2.value should be(true)
+      m2.enabled should be(true)
+    }
+
+    "have unapply extractor" in {
+      val f1 = Flag.empty.switchOn
+      val Flag(value1) = f1
+      val value2: Boolean = value1
+      Changed("key", f1) match {
+        case Changed("key", Flag(value3)) =>
+          val value4: Boolean = value3
+          value4 should be(true)
+      }
     }
   }
 }

--- a/src/test/scala/akka/contrib/datareplication/GCounterSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/GCounterSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.WordSpec
 import org.scalatest.Matchers
 import akka.actor.Address
 import akka.cluster.UniqueAddress
+import akka.contrib.datareplication.Replicator.Changed
 
 class GCounterSpec extends WordSpec with Matchers {
   val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
@@ -148,6 +149,17 @@ class GCounterSpec extends WordSpec with Matchers {
 
       val c5 = (c4 increment node1).pruningCleanup(node1)
       c5.needPruningFrom(node1) should be(false)
+    }
+
+    "have unapply extractor" in {
+      val c1 = GCounter.empty.increment(node1).increment(node2)
+      val GCounter(value1) = c1
+      val value2: Long = value1
+      Changed("key", c1) match {
+        case Changed("key", GCounter(value3)) =>
+          val value4: Long = value3
+          value4 should be(2L)
+      }
     }
 
   }

--- a/src/test/scala/akka/contrib/datareplication/GSetSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/GSetSpec.scala
@@ -6,6 +6,7 @@ package akka.contrib.datareplication
 
 import org.scalatest.WordSpec
 import org.scalatest.Matchers
+import akka.contrib.datareplication.Replicator.Changed
 
 class GSetSpec extends WordSpec with Matchers {
 
@@ -25,10 +26,10 @@ class GSetSpec extends WordSpec with Matchers {
       val c4 = c3 + user4
       val c5 = c4 + user3
 
-      c5.value should contain(user1)
-      c5.value should contain(user2)
-      c5.value should contain(user3)
-      c5.value should contain(user4)
+      c5.elements should contain(user1)
+      c5.elements should contain(user2)
+      c5.elements should contain(user3)
+      c5.elements should contain(user4)
     }
 
     "be able to have its user set correctly merged with another GSet with unique user sets" in {
@@ -38,8 +39,8 @@ class GSetSpec extends WordSpec with Matchers {
       val c12 = c11 + user1
       val c13 = c12 + user2
 
-      c13.value should contain(user1)
-      c13.value should contain(user2)
+      c13.elements should contain(user1)
+      c13.elements should contain(user2)
 
       // set 2
       val c21 = GSet.empty[String]
@@ -47,21 +48,21 @@ class GSetSpec extends WordSpec with Matchers {
       val c22 = c21 + user3
       val c23 = c22 + user4
 
-      c23.value should contain(user3)
-      c23.value should contain(user4)
+      c23.elements should contain(user3)
+      c23.elements should contain(user4)
 
       // merge both ways
       val merged1 = c13 merge c23
-      merged1.value should contain(user1)
-      merged1.value should contain(user2)
-      merged1.value should contain(user3)
-      merged1.value should contain(user4)
+      merged1.elements should contain(user1)
+      merged1.elements should contain(user2)
+      merged1.elements should contain(user3)
+      merged1.elements should contain(user4)
 
       val merged2 = c23 merge c13
-      merged2.value should contain(user1)
-      merged2.value should contain(user2)
-      merged2.value should contain(user3)
-      merged2.value should contain(user4)
+      merged2.elements should contain(user1)
+      merged2.elements should contain(user2)
+      merged2.elements should contain(user3)
+      merged2.elements should contain(user4)
     }
 
     "be able to have its user set correctly merged with another GSet with overlapping user sets" in {
@@ -72,9 +73,9 @@ class GSetSpec extends WordSpec with Matchers {
       val c12 = c11 + user2
       val c13 = c12 + user3
 
-      c13.value should contain(user1)
-      c13.value should contain(user2)
-      c13.value should contain(user3)
+      c13.elements should contain(user1)
+      c13.elements should contain(user2)
+      c13.elements should contain(user3)
 
       // set 2
       val c20 = GSet.empty[String]
@@ -83,22 +84,34 @@ class GSetSpec extends WordSpec with Matchers {
       val c22 = c21 + user3
       val c23 = c22 + user4
 
-      c23.value should contain(user2)
-      c23.value should contain(user3)
-      c23.value should contain(user4)
+      c23.elements should contain(user2)
+      c23.elements should contain(user3)
+      c23.elements should contain(user4)
 
       // merge both ways
       val merged1 = c13 merge c23
-      merged1.value should contain(user1)
-      merged1.value should contain(user2)
-      merged1.value should contain(user3)
-      merged1.value should contain(user4)
+      merged1.elements should contain(user1)
+      merged1.elements should contain(user2)
+      merged1.elements should contain(user3)
+      merged1.elements should contain(user4)
 
       val merged2 = c23 merge c13
-      merged2.value should contain(user1)
-      merged2.value should contain(user2)
-      merged2.value should contain(user3)
-      merged2.value should contain(user4)
+      merged2.elements should contain(user1)
+      merged2.elements should contain(user2)
+      merged2.elements should contain(user3)
+      merged2.elements should contain(user4)
+    }
+
+    "have unapply extractor" in {
+      val s1 = GSet.empty + "a" + "b"
+      val s2: GSet[String] = s1
+      val GSet(elements1) = s1
+      val elements2: Set[String] = elements1
+      Changed("key", s1) match {
+        case Changed("key", GSet(elements3)) =>
+          val elements4: Set[Any] = elements3
+          elements4 should be(Set("a", "b"))
+      }
     }
 
   }

--- a/src/test/scala/akka/contrib/datareplication/LWWMapSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/LWWMapSpec.scala
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2009-2014 Typesafe Inc. <http://www.typesafe.com>
+ */
+
+package akka.contrib.datareplication
+
+import org.scalatest.WordSpec
+import org.scalatest.Matchers
+import akka.actor.Address
+import akka.cluster.UniqueAddress
+import akka.contrib.datareplication.Replicator.Changed
+
+class LWWMapSpec extends WordSpec with Matchers {
+  import LWWRegister.defaultClock
+
+  val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
+  val node2 = UniqueAddress(node1.address.copy(port = Some(2552)), 2)
+
+  "A LWWMap" must {
+
+    "be able to set entries" in {
+      val m = LWWMap().put(node1, "a", 1, defaultClock).put(node2, "b", 2, defaultClock)
+      m.entries should be(Map("a" -> 1, "b" -> 2))
+    }
+
+    "be able to have its entries correctly merged with another LWWMap with other entries" in {
+      val m1 = LWWMap.empty.put(node1, "a", 1, defaultClock).put(node1, "b", 2, defaultClock)
+      val m2 = LWWMap.empty.put(node2, "c", 3, defaultClock)
+
+      // merge both ways
+      val expected = Map("a" -> 1, "b" -> 2, "c" -> 3)
+      (m1 merge m2).entries should be(expected)
+      (m2 merge m1).entries should be(expected)
+    }
+
+    "be able to remove entry" in {
+      val m1 = LWWMap.empty.put(node1, "a", 1, defaultClock).put(node1, "b", 2, defaultClock)
+      val m2 = LWWMap.empty.put(node2, "c", 3, defaultClock)
+
+      val merged1 = m1 merge m2
+
+      val m3 = merged1.remove(node1, "b")
+      (merged1 merge m3).entries should be(Map("a" -> 1, "c" -> 3))
+
+      // but if there is a conflicting update the entry is not removed
+      val m4 = merged1.put(node2, "b", 22, defaultClock)
+      (m3 merge m4).entries should be(Map("a" -> 1, "b" -> 22, "c" -> 3))
+    }
+
+    "have unapply extractor" in {
+      val m1 = LWWMap.empty.put(node1, "a", 1L, defaultClock)
+      val LWWMap(entries1) = m1
+      val entries2: Map[String, Long] = entries1
+      Changed("key", m1) match {
+        case Changed("key", LWWMap(entries3)) =>
+          val entries4: Map[String, Any] = entries3
+          entries4 should be(Map("a" -> 1L))
+      }
+    }
+
+  }
+}

--- a/src/test/scala/akka/contrib/datareplication/LWWRegisterSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/LWWRegisterSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.WordSpec
 import org.scalatest.Matchers
 import akka.actor.Address
 import akka.cluster.UniqueAddress
+import akka.contrib.datareplication.Replicator.Changed
 
 class LWWRegisterSpec extends WordSpec with Matchers {
   import LWWRegister.defaultClock
@@ -61,6 +62,17 @@ class LWWRegisterSpec extends WordSpec with Matchers {
           val r2 = r.withValue(node1, n, defaultClock)
           r2.timestamp should be > r.timestamp
           r2
+      }
+    }
+
+    "have unapply extractor" in {
+      val r1 = LWWRegister(node1, "a", defaultClock)
+      val LWWRegister(value1) = r1
+      val value2: String = value1
+      Changed("key", r1) match {
+        case Changed("key", LWWRegister(value3)) =>
+          val value4: Any = value3
+          value4 should be("a")
       }
     }
   }

--- a/src/test/scala/akka/contrib/datareplication/ORMultiMapSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/ORMultiMapSpec.scala
@@ -5,7 +5,8 @@ package akka.contrib.datareplication
 
 import akka.actor.Address
 import akka.cluster.UniqueAddress
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
+import akka.contrib.datareplication.Replicator.Changed
 
 class ORMultiMapSpec extends WordSpec with Matchers {
 
@@ -41,8 +42,7 @@ class ORMultiMapSpec extends WordSpec with Matchers {
       val expectedMerge = Map(
         "a" -> Set("A"),
         "b" -> Set("B"),
-        "c" -> Set("C")
-      )
+        "c" -> Set("C"))
 
       val merged1 = m1 merge m2
       merged1.entries should be(expectedMerge)
@@ -70,8 +70,7 @@ class ORMultiMapSpec extends WordSpec with Matchers {
         "a" -> Set("A2"),
         "b" -> Set("B1"),
         "c" -> Set("C2"),
-        "d" -> Set("D1", "D2")
-      )
+        "d" -> Set("D1", "D2"))
 
       val merged1 = m1 merge m2
       merged1.entries should be(expectedMerged)
@@ -91,8 +90,7 @@ class ORMultiMapSpec extends WordSpec with Matchers {
 
     val expectedMerged = Map(
       "a" -> Set("A2"),
-      "b" -> Set("B1")
-    )
+      "b" -> Set("B1"))
 
     m2.entries should be(expectedMerged)
   }
@@ -107,5 +105,17 @@ class ORMultiMapSpec extends WordSpec with Matchers {
     val m = ORMultiMap().addBinding(node1, "a", "A1").addBinding(node1, "a", "A2").addBinding(node1, "b", "B1")
     val m2 = m.remove(node1, "a")
     m2.entries should be(Map("b" -> Set("B1")))
+  }
+
+  "have unapply extractor" in {
+    val m1 = ORMultiMap.empty.put(node1, "a", Set(1L, 2L)).put(node2, "b", Set(3L))
+    val m2: ORMultiMap[Long] = m1
+    val ORMultiMap(entries1) = m1
+    val entries2: Map[String, Set[Long]] = entries1
+    Changed("key", m1) match {
+      case Changed("key", ORMultiMap(entries3)) =>
+        val entries4: Map[String, Set[Any]] = entries3
+        entries4 should be(Map("a" -> Set(1L, 2L), "b" -> Set(3L)))
+    }
   }
 }

--- a/src/test/scala/akka/contrib/datareplication/ORSetSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/ORSetSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.Matchers
 import scala.collection.immutable.TreeMap
 import akka.actor.Address
 import akka.cluster.UniqueAddress
+import akka.contrib.datareplication.Replicator.Changed
 
 class ORSetSpec extends WordSpec with Matchers {
 
@@ -40,10 +41,10 @@ class ORSetSpec extends WordSpec with Matchers {
       val c4 = c3.add(node1, user4)
       val c5 = c4.add(node1, user3)
 
-      c5.value should contain(user1)
-      c5.value should contain(user2)
-      c5.value should contain(user3)
-      c5.value should contain(user4)
+      c5.elements should contain(user1)
+      c5.elements should contain(user2)
+      c5.elements should contain(user3)
+      c5.elements should contain(user4)
     }
 
     "be able to remove added user" in {
@@ -55,19 +56,19 @@ class ORSetSpec extends WordSpec with Matchers {
       val c4 = c3.remove(node1, user2)
       val c5 = c4.remove(node1, user1)
 
-      c5.value should not contain (user1)
-      c5.value should not contain (user2)
+      c5.elements should not contain (user1)
+      c5.elements should not contain (user2)
     }
 
     "be able to add removed" in {
       val c1 = ORSet()
       val c2 = c1.remove(node1, user1)
       val c3 = c2.add(node1, user1)
-      c3.value should contain(user1)
+      c3.elements should contain(user1)
       val c4 = c3.remove(node1, user1)
-      c4.value should not contain (user1)
+      c4.elements should not contain (user1)
       val c5 = c4.add(node1, user1)
-      c5.value should contain(user1)
+      c5.elements should contain(user1)
     }
 
     "be able to remove and add several times" in {
@@ -76,115 +77,115 @@ class ORSetSpec extends WordSpec with Matchers {
       val c2 = c1.add(node1, user1)
       val c3 = c2.add(node1, user2)
       val c4 = c3.remove(node1, user1)
-      c4.value should not contain (user1)
-      c4.value should contain(user2)
+      c4.elements should not contain (user1)
+      c4.elements should contain(user2)
 
       val c5 = c4.add(node1, user1)
       val c6 = c5.add(node1, user2)
-      c6.value should contain(user1)
-      c6.value should contain(user2)
+      c6.elements should contain(user1)
+      c6.elements should contain(user2)
 
       val c7 = c6.remove(node1, user1)
       val c8 = c7.add(node1, user2)
       val c9 = c8.remove(node1, user1)
-      c9.value should not contain (user1)
-      c9.value should contain(user2)
+      c9.elements should not contain (user1)
+      c9.elements should contain(user2)
     }
 
     "be able to have its user set correctly merged with another ORSet with unique user sets" in {
       // set 1
       val c1 = ORSet().add(node1, user1).add(node1, user2)
-      c1.value should contain(user1)
-      c1.value should contain(user2)
+      c1.elements should contain(user1)
+      c1.elements should contain(user2)
 
       // set 2
       val c2 = ORSet().add(node2, user3).add(node2, user4).remove(node2, user3)
 
-      c2.value should not contain (user3)
-      c2.value should contain(user4)
+      c2.elements should not contain (user3)
+      c2.elements should contain(user4)
 
       // merge both ways
       val merged1 = c1 merge c2
-      merged1.value should contain(user1)
-      merged1.value should contain(user2)
-      merged1.value should not contain (user3)
-      merged1.value should contain(user4)
+      merged1.elements should contain(user1)
+      merged1.elements should contain(user2)
+      merged1.elements should not contain (user3)
+      merged1.elements should contain(user4)
 
       val merged2 = c2 merge c1
-      merged2.value should contain(user1)
-      merged2.value should contain(user2)
-      merged2.value should not contain (user3)
-      merged2.value should contain(user4)
+      merged2.elements should contain(user1)
+      merged2.elements should contain(user2)
+      merged2.elements should not contain (user3)
+      merged2.elements should contain(user4)
     }
 
     "be able to have its user set correctly merged with another ORSet with overlapping user sets" in {
       // set 1
       val c1 = ORSet().add(node1, user1).add(node1, user2).add(node1, user3).remove(node1, user1).remove(node1, user3)
 
-      c1.value should not contain (user1)
-      c1.value should contain(user2)
-      c1.value should not contain (user3)
+      c1.elements should not contain (user1)
+      c1.elements should contain(user2)
+      c1.elements should not contain (user3)
 
       // set 2
       val c2 = ORSet().add(node2, user1).add(node2, user2).add(node2, user3).add(node2, user4).remove(node2, user3)
 
-      c2.value should contain(user1)
-      c2.value should contain(user2)
-      c2.value should not contain (user3)
-      c2.value should contain(user4)
+      c2.elements should contain(user1)
+      c2.elements should contain(user2)
+      c2.elements should not contain (user3)
+      c2.elements should contain(user4)
 
       // merge both ways
       val merged1 = c1 merge c2
-      merged1.value should contain(user1)
-      merged1.value should contain(user2)
-      merged1.value should not contain (user3)
-      merged1.value should contain(user4)
+      merged1.elements should contain(user1)
+      merged1.elements should contain(user2)
+      merged1.elements should not contain (user3)
+      merged1.elements should contain(user4)
 
       val merged2 = c2 merge c1
-      merged2.value should contain(user1)
-      merged2.value should contain(user2)
-      merged2.value should not contain (user3)
-      merged2.value should contain(user4)
+      merged2.elements should contain(user1)
+      merged2.elements should contain(user2)
+      merged2.elements should not contain (user3)
+      merged2.elements should contain(user4)
     }
 
     "be able to have its user set correctly merged for concurrent updates" in {
       val c1 = ORSet().add(node1, user1).add(node1, user2).add(node1, user3)
 
-      c1.value should contain(user1)
-      c1.value should contain(user2)
-      c1.value should contain(user3)
+      c1.elements should contain(user1)
+      c1.elements should contain(user2)
+      c1.elements should contain(user3)
 
       val c2 = c1.add(node2, user1).remove(node2, user2).remove(node2, user3)
 
-      c2.value should contain(user1)
-      c2.value should not contain (user2)
-      c2.value should not contain (user3)
+      c2.elements should contain(user1)
+      c2.elements should not contain (user2)
+      c2.elements should not contain (user3)
 
       // merge both ways
       val merged1 = c1 merge c2
-      merged1.value should contain(user1)
-      merged1.value should not contain (user2)
-      merged1.value should not contain (user3)
+      merged1.elements should contain(user1)
+      merged1.elements should not contain (user2)
+      merged1.elements should not contain (user3)
 
       val merged2 = c2 merge c1
-      merged2.value should contain(user1)
-      merged2.value should not contain (user2)
-      merged2.value should not contain (user3)
+      merged2.elements should contain(user1)
+      merged2.elements should not contain (user2)
+      merged2.elements should not contain (user3)
 
       val c3 = c1.add(node1, user4).remove(node1, user3).add(node1, user2)
 
       // merge both ways
       val merged3 = c2 merge c3
-      merged3.value should contain(user1)
-      merged3.value should contain(user2)
-      merged3.value should not contain (user3)
-      merged3.value should contain(user4)
+      merged3.elements should contain(user1)
+      merged3.elements should contain(user2)
+      merged3.elements should not contain (user3)
+      merged3.elements should contain(user4)
 
       val merged4 = c3 merge c2
-      merged4.value should contain(user1)
-      merged4.value should contain(user2)
-      merged4.value should not contain (user3)
-      merged4.value should contain(user4)
+      merged4.elements should contain(user1)
+      merged4.elements should contain(user2)
+      merged4.elements should not contain (user3)
+      merged4.elements should contain(user4)
     }
 
     "be able to have its user set correctly merged after remove" in {
@@ -193,25 +194,25 @@ class ORSetSpec extends WordSpec with Matchers {
 
       // merge both ways
       val merged1 = c1 merge c2
-      merged1.value should contain(user1)
-      merged1.value should not contain (user2)
+      merged1.elements should contain(user1)
+      merged1.elements should not contain (user2)
 
       val merged2 = c2 merge c1
-      merged2.value should contain(user1)
-      merged2.value should not contain (user2)
+      merged2.elements should contain(user1)
+      merged2.elements should not contain (user2)
 
       val c3 = c1.add(node1, user3)
 
       // merge both ways
       val merged3 = c3 merge c2
-      merged3.value should contain(user1)
-      merged3.value should not contain (user2)
-      merged3.value should contain(user3)
+      merged3.elements should contain(user1)
+      merged3.elements should not contain (user2)
+      merged3.elements should contain(user3)
 
       val merged4 = c2 merge c3
-      merged4.value should contain(user1)
-      merged4.value should not contain (user2)
-      merged4.value should contain(user3)
+      merged4.elements should contain(user1)
+      merged4.elements should not contain (user2)
+      merged4.elements should contain(user3)
     }
 
   }
@@ -230,13 +231,13 @@ class ORSetSpec extends WordSpec with Matchers {
       val thisDot2 = new VectorClock(TreeMap(nodeB -> 5, nodeC -> 2))
       val thisVclock = new VectorClock(TreeMap(nodeA -> 3, nodeB -> 5, nodeC -> 2, nodeD -> 7))
       val thisSet = new ORSet(
-        elements = Map("K1" -> thisDot1, "K2" -> thisDot2),
+        elementsMap = Map("K1" -> thisDot1, "K2" -> thisDot2),
         vclock = thisVclock)
       val thatDot1 = new VectorClock(TreeMap(nodeA -> 3))
       val thatDot2 = new VectorClock(TreeMap(nodeB -> 6))
       val thatVclock = new VectorClock(TreeMap(nodeA -> 3, nodeB -> 6, nodeC -> 1, nodeD -> 8))
       val thatSet = new ORSet(
-        elements = Map("K1" -> thatDot1, "K2" -> thatDot2),
+        elementsMap = Map("K1" -> thatDot1, "K2" -> thatDot2),
         vclock = thatVclock)
 
       val expectedDots = Map(
@@ -267,7 +268,7 @@ class ORSetSpec extends WordSpec with Matchers {
       val c = a1.merge(b1)
       val a2 = a1.remove(node1, "bar")
       val d = a2.merge(c)
-      d.value should be(Set("baz"))
+      d.elements should be(Set("baz"))
     }
 
     "verify removed after merge" in {
@@ -282,22 +283,22 @@ class ORSetSpec extends WordSpec with Matchers {
       // Replicate b to node1, so now node1 has a Z, the one with a Dot of
       // {node2 -> 1} and clock of [{node1 -> 1}, {node2 -> 1}]
       val a3 = b.merge(a2)
-      a3.value should be(Set("Z"))
+      a3.elements should be(Set("Z"))
       // Remove the 'Z' at node2 replica
       val b2 = b.remove(node2, "Z")
       // Both node3 (c) and node1 (a3) have a 'Z', but when they merge, there should be
       // no 'Z' as node3 (c)'s has been removed by node1 and node1 (a3)'s has been removed by
       // node2
-      c.value should be(Set("Z"))
-      a3.value should be(Set("Z"))
-      b2.value should be(Set())
+      c.elements should be(Set("Z"))
+      a3.elements should be(Set("Z"))
+      b2.elements should be(Set())
 
-      a3.merge(c).merge(b2).value should be(Set.empty)
-      a3.merge(b2).merge(c).value should be(Set.empty)
-      c.merge(b2).merge(a3).value should be(Set.empty)
-      c.merge(a3).merge(b2).value should be(Set.empty)
-      b2.merge(c).merge(a3).value should be(Set.empty)
-      b2.merge(a3).merge(c).value should be(Set.empty)
+      a3.merge(c).merge(b2).elements should be(Set.empty)
+      a3.merge(b2).merge(c).elements should be(Set.empty)
+      c.merge(b2).merge(a3).elements should be(Set.empty)
+      c.merge(a3).merge(b2).elements should be(Set.empty)
+      b2.merge(c).merge(a3).elements should be(Set.empty)
+      b2.merge(a3).merge(c).elements should be(Set.empty)
     }
 
     "verify removed after merge 2" in {
@@ -308,19 +309,34 @@ class ORSetSpec extends WordSpec with Matchers {
       val a2 = a.remove(node1, "Z")
       // replicate b to node1, now node1 has node2's 'Z'
       val a3 = a2.merge(b)
-      a3.value should be(Set("Z"))
+      a3.elements should be(Set("Z"))
       // Remove node2's 'Z'
       val b2 = b.remove(node2, "Z")
       // Replicate c to node2, now node2 has node1's old 'Z'
       val b3 = b2.merge(c)
-      b3.value should be(Set("Z"))
+      b3.elements should be(Set("Z"))
       // Merge everytyhing
-      a3.merge(c).merge(b3).value should be(Set.empty)
-      a3.merge(b3).merge(c).value should be(Set.empty)
-      c.merge(b3).merge(a3).value should be(Set.empty)
-      c.merge(a3).merge(b3).value should be(Set.empty)
-      b3.merge(c).merge(a3).value should be(Set.empty)
-      b3.merge(a3).merge(c).value should be(Set.empty)
+      a3.merge(c).merge(b3).elements should be(Set.empty)
+      a3.merge(b3).merge(c).elements should be(Set.empty)
+      c.merge(b3).merge(a3).elements should be(Set.empty)
+      c.merge(a3).merge(b3).elements should be(Set.empty)
+      b3.merge(c).merge(a3).elements should be(Set.empty)
+      b3.merge(a3).merge(c).elements should be(Set.empty)
+    }
+
+    "have unapply extractor" in {
+      val s1 = ORSet.empty.add(node1, "a").add(node2, "b")
+      val s2: ORSet[String] = s1
+      val ORSet(elements1) = s1 // `unapply[A](s: ORSet[A])` is used here
+      val elements2: Set[String] = elements1
+      Changed("key", s1) match {
+        case Changed("key", ORSet(elements3)) => // `unapply(a: ReplicatedData)` is used here
+          // if `unapply(a: ReplicatedData)` isn't defined the next line doesn't compile:
+          //   type mismatch; found : scala.collection.immutable.Set[A] where type A required: Set[Any] Note: A <: Any,
+          //   but trait Set is invariant in type A. You may wish to investigate a wildcard type such as _ <: Any. (SLS 3.2.10)
+          val elements4: Set[Any] = elements3
+          elements4 should be(Set("a", "b"))
+      }
     }
 
   }

--- a/src/test/scala/akka/contrib/datareplication/PNCounterMapSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/PNCounterMapSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.WordSpec
 import org.scalatest.Matchers
 import akka.actor.Address
 import akka.cluster.UniqueAddress
+import akka.contrib.datareplication.Replicator.Changed
 
 class PNCounterMapSpec extends WordSpec with Matchers {
 
@@ -43,6 +44,17 @@ class PNCounterMapSpec extends WordSpec with Matchers {
       // but if there is a conflicting update the entry is not removed
       val m4 = merged1.increment(node2, "b", 10)
       (m3 merge m4).entries should be(Map("a" -> 1, "b" -> 13, "c" -> 7))
+    }
+
+    "have unapply extractor" in {
+      val m1 = PNCounterMap.empty.increment(node1, "a", 1).increment(node2, "b", 2)
+      val PNCounterMap(entries1) = m1
+      val entries2: Map[String, Long] = entries1
+      Changed("key", m1) match {
+        case Changed("key", PNCounterMap(entries3)) =>
+          val entries4: Map[String, Long] = entries3
+          entries4 should be(Map("a" -> 1L, "b" -> 2L))
+      }
     }
 
   }

--- a/src/test/scala/akka/contrib/datareplication/PNCounterSpec.scala
+++ b/src/test/scala/akka/contrib/datareplication/PNCounterSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.WordSpec
 import org.scalatest.Matchers
 import akka.actor.Address
 import akka.cluster.UniqueAddress
+import akka.contrib.datareplication.Replicator.Changed
 
 class PNCounterSpec extends WordSpec with Matchers {
   val node1 = UniqueAddress(Address("akka.tcp", "Sys", "localhost", 2551), 1)
@@ -153,6 +154,17 @@ class PNCounterSpec extends WordSpec with Matchers {
 
       val c5 = (c4 increment node1).pruningCleanup(node1)
       c5.needPruningFrom(node1) should be(false)
+    }
+
+    "have unapply extractor" in {
+      val c1 = PNCounter.empty.increment(node1).increment(node1).decrement(node2)
+      val PNCounter(value1) = c1
+      val value2: Long = value1
+      Changed("key", c1) match {
+        case Changed("key", PNCounter(value3)) =>
+          val value4: Long = value3
+          value4 should be(1L)
+      }
     }
 
   }


### PR DESCRIPTION
* Had to skip case class for some types to be able to define
  the unapply that we want.
* Added tests for unapply
* Various minor doc improvements
* Fixed type bug in multimap getEntries
* API change: ORMap.value and GSet.value renamed to elements
* API change: Flag.value renamed to enabled
* SerialVersionUID, in case they are embedded in other
  classes that use Java serialization